### PR TITLE
Add mocked wallets and transactions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -34,7 +34,9 @@ Commands _**2**_ and _**3**_ should be executed on the first setup and only when
 1. edit the **API_URL_PREFIX** with the local server<br/>
    `API_URL_PREFIX='http://127.0.0.1:3000'`
 1. edit the **CONTENT_REPO_URL** with the local server<br/>
-   `CONTENT_REPO_URL='http://127.0.0.1:3000/static_contents''`
+   `CONTENT_REPO_URL='http://127.0.0.1:3000/static_contents'`
+1. edit the **PAGOPA_API_URL_PREFIX** with the local server <br/>
+    `PAGOPA_API_URL_PREFIX='http://127.0.0.1:3000/wallet'`
 1. update the config file<br/>
    `yarn postinstall`
 1. run simulator<br/>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test": "jest",
     "test-watch": "jest --watch",
     "build": "tsc",
+    "lint": "tslint -p . -t verbose",
+    "lint-autofix": "tslint -p . -t verbose --fix",
     "start": "npm-run-all build && node build/src/start.js",
     "generate:paths": "ts-node src/utils/paths_generator.ts",
     "generate:content-definitions": "rimraf generated/definitions/content && mkdir -p generated/definitions/content && gen-api-models --api-spec https://raw.githubusercontent.com/teamdigitale/italia-services-metadata/master/definitions.yml --out-dir ./generated/definitions/content",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "generate:paths": "ts-node src/utils/paths_generator.ts",
     "generate:content-definitions": "rimraf generated/definitions/content && mkdir -p generated/definitions/content && gen-api-models --api-spec https://raw.githubusercontent.com/teamdigitale/italia-services-metadata/master/definitions.yml --out-dir ./generated/definitions/content",
     "generate:models": "rimraf generated && rimraf generated/definitions/backend && mkdir -p generated/definitions/backend && gen-api-models --api-spec $npm_package_api_beckend_specs --out-dir ./generated/definitions/backend --no-strict --request-types && gen-api-models --api-spec $npm_package_api_public_specs --out-dir generated/definitions/backend",
-    "generate:all": "npm-run-all generate:models generate:content-definitions generate:paths"
+    "generate:pagopa-api-definitions": "rimraf generated/definitions/pagopa && mkdir -p generated/definitions/pagopa && gen-api-models --api-spec https://wisp2.pagopa.gov.it/pp-restapi-CD/v2/api-docs --out-dir ./generated/definitions/pagopa --no-strict --request-types --response-decoders --default-error-type undefined",
+    "generate:all": "npm-run-all generate:models generate:content-definitions generate:paths generate:pagopa-api-definitions"
   },
   "dependencies": {
     "@types/body-parser": "^1.17.1",

--- a/payloads/message.ts
+++ b/payloads/message.ts
@@ -2,10 +2,10 @@ import { range } from "fp-ts/lib/Array";
 import { CreatedMessageWithContent } from "../generated/definitions/backend/CreatedMessageWithContent";
 import { CreatedMessageWithoutContent } from "../generated/definitions/backend/CreatedMessageWithoutContent";
 import { PaginatedCreatedMessageWithoutContentCollection } from "../generated/definitions/backend/PaginatedCreatedMessageWithoutContentCollection";
+import { PaymentNoticeNumber } from "../generated/definitions/backend/PaymentNoticeNumber";
+import { getRandomStringId } from "../src/utils/id";
 import { validatePayload } from "../src/utils/validator";
 import { IOResponse } from "./response";
-import { getRandomStringId } from "../src/utils/id";
-
 
 /**
  * generate a list containg count messages with the given fiscal_code
@@ -58,7 +58,11 @@ export const createMessageWithContent = (
         subject: `subject [${serviceId}]`,
         markdown:
           "😊 this is a mock message this is a mock message this is a mock message this is a mock message",
-        due_date: date
+        due_date: date,
+        payment_data: {
+          amount: 12300,
+          notice_number: "012345678912345678" as PaymentNoticeNumber
+        }
       },
       created_at: date,
       fiscal_code: fiscalCode,

--- a/payloads/message.ts
+++ b/payloads/message.ts
@@ -4,19 +4,8 @@ import { CreatedMessageWithoutContent } from "../generated/definitions/backend/C
 import { PaginatedCreatedMessageWithoutContentCollection } from "../generated/definitions/backend/PaginatedCreatedMessageWithoutContentCollection";
 import { validatePayload } from "../src/utils/validator";
 import { IOResponse } from "./response";
+import { getRandomStringId } from "../src/utils/id";
 
-/**
- * generate a 26 chars pseudo-random string
- */
-const getRandomId = (): string => {
-  const randomSlice = () =>
-    Math.random()
-      .toString(36)
-      .substring(2, 15);
-  return (randomSlice() + randomSlice() + randomSlice())
-    .substring(0, 26)
-    .toUpperCase();
-};
 
 /**
  * generate a list containg count messages with the given fiscal_code
@@ -33,7 +22,7 @@ const createMessage = (
     const date = new Date();
     const msgId =
       randomId === true
-        ? getRandomId()
+        ? getRandomStringId()
         : messageId
         ? messageId
         : `${idx}`.padStart(26, "0");
@@ -59,7 +48,7 @@ export const createMessageWithContent = (
     const date = new Date();
     const msgId =
       randomId === true
-        ? getRandomId()
+        ? getRandomStringId()
         : messageId
         ? messageId
         : `${idx}`.padStart(26, "0");

--- a/payloads/wallet.ts
+++ b/payloads/wallet.ts
@@ -1,0 +1,122 @@
+import { Transaction } from "../generated/definitions/pagopa/Transaction";
+import { range } from "fp-ts/lib/Array";
+import { Wallet } from "../generated/definitions/pagopa/Wallet";
+import { CreditCard } from "../generated/definitions/pagopa/CreditCard";
+import { Psp } from "../generated/definitions/pagopa/Psp";
+import { validatePayload } from "../src/utils/validator";
+import { SessionResponse } from "../generated/definitions/pagopa/SessionResponse";
+import { WalletResponse } from "../generated/definitions/pagopa/WalletResponse";
+import { TransactionResponse } from "../generated/definitions/pagopa/TransactionResponse";
+import { getRandomIntId } from "../src/utils/id";
+
+export const sessionToken: SessionResponse = {
+    data: {
+        sessionToken: '3m3Q2h6e8T5w9t3W8b8y1F4t2m6Q9b8d9N6h1f2H2u0g6E7m9d9E3g7w3T3b5a7I4c4h6U4n2b3Z4p3j8D6p4a5G1c4a8K3o0v8P7e0j6R5i1y2J6d0c7N9i6m0U3j9z'
+    }
+}
+
+export const getWallets = (): WalletResponse => {
+    const validCreditCard: { [key: string]: any } = {
+        id: 1464,
+        holder: "Mario Rossi",
+        pan: "************0111",
+        expireMonth: "05",
+        expireYear: "22",
+        brandLogo:
+          "https://wisp2.pagopa.gov.it/wallet/assets/img/creditcard/carta_mc.png",
+        flag3dsVerified: true
+    };
+  
+    const validAmount: { [key: string]: any } = {
+        currency: "EUR",
+        amount: 1000,
+        decimalDigits: 2
+    };
+  
+    const validPsp: { [key: string]: any } = {
+        id: 43188,
+        idPsp: "idPsp1",
+        businessName: "WHITE bank",
+        paymentType: "CP",
+        idIntermediary: "idIntermediario1",
+        idChannel: "idCanale14",
+        logoPSP:
+          "https://wisp2.pagopa.gov.it/pp-restapi/v2/resources/psp/1578833",
+        serviceLogo:
+          "https://wisp2.pagopa.gov.it/pp-restapi/v2/resources/service/1578833",
+        serviceName: "nomeServizio 10 white",
+        fixedCost: validAmount,
+        appChannel: false,
+        tags: ["MAESTRO"],
+        serviceDescription: "DESCRIZIONE servizio: CP mod1",
+        serviceAvailability: "DISPONIBILITA servizio 24/7",
+        paymentModel: 1,
+        flagStamp: true,
+        idCard: 91,
+        lingua: "IT"
+    };
+
+    enum TypeEnum {
+        "CREDIT_CARD" = "CREDIT_CARD",
+        "BANK_ACCOUNT" = "BANK_ACCOUNT",
+        "EXTERNAL_PS" = "EXTERNAL_PS"
+    };
+  
+    const WalletCard: Wallet = {
+        idWallet: 12345,
+        type: TypeEnum.CREDIT_CARD,
+        favourite: false,
+        creditCard: validCreditCard as CreditCard,
+        psp: validPsp as Psp,
+        idPsp: validPsp.id,
+        pspEditable: true,
+        lastUsage: new Date("2018-08-07T15:50:08Z")
+    };
+  
+    // It is displayed as card!
+    const WalletBank: Wallet = {
+        idWallet: 67890,
+        type: TypeEnum.CREDIT_CARD,
+        creditCard: validCreditCard as CreditCard,
+        psp: validPsp as Psp,
+        idPsp: validPsp.id,
+        pspEditable: true,
+        lastUsage: new Date("2018-08-07T15:50:08Z")
+    };
+  
+    return {
+        data: [WalletBank, WalletCard]
+    } ;   
+}
+
+export const getTransactions = (amount: number): TransactionResponse => {
+    return {
+        data: range(1, amount).map(_ => {
+            return ({
+                accountingStatus: 1,
+                amount: {amount: 20000},
+                created: new Date(2018,10,30,13,12,22,30),
+                description: 'transaction n.' + _,
+                error: false,
+                fee: {amount: 1},
+                grandTotal: {amount: 20100},
+                id: getRandomIntId(5),
+                idPayment: 1,
+                idPsp: 43188,
+                idStatus: 3,
+                idWallet: 12345,
+                merchant: 'merchant',
+                nodoIdPayment: 'nodoIdPayment' ,
+                paymentModel: 5,
+                spcNodeDescription: 'spcNodeDescription',
+                spcNodeStatus: 6,
+                statusMessage: 'statusMessage',
+                success: true,
+                token: 'token',
+                updated: undefined,
+                urlCheckout3ds: 'urlCheckout3ds',
+                urlRedirectPSP: 'urlRedirectPSP'
+            });
+        })
+    } 
+}

--- a/payloads/wallet.ts
+++ b/payloads/wallet.ts
@@ -1,126 +1,119 @@
-import { Transaction } from "../generated/definitions/pagopa/Transaction";
 import { range } from "fp-ts/lib/Array";
-import { Wallet } from "../generated/definitions/pagopa/Wallet";
 import { CreditCard } from "../generated/definitions/pagopa/CreditCard";
 import { Psp } from "../generated/definitions/pagopa/Psp";
-import { validatePayload } from "../src/utils/validator";
 import { SessionResponse } from "../generated/definitions/pagopa/SessionResponse";
-import { getRandomIntId } from "../src/utils/id";
+import { Transaction } from "../generated/definitions/pagopa/Transaction";
 import { TransactionListResponse } from "../generated/definitions/pagopa/TransactionListResponse";
+import { TypeEnum, Wallet } from "../generated/definitions/pagopa/Wallet";
 import { WalletListResponse } from "../generated/definitions/pagopa/WalletListResponse";
+import { getRandomIntId } from "../src/utils/id";
+import { validatePayload } from "../src/utils/validator";
 
 export const sessionToken: SessionResponse = {
-    data: {
-        sessionToken: '3m3Q2h6e8T5w9t3W8b8y1F4t2m6Q9b8d9N6h1f2H2u0g6E7m9d9E3g7w3T3b5a7I4c4h6U4n2b3Z4p3j8D6p4a5G1c4a8K3o0v8P7e0j6R5i1y2J6d0c7N9i6m0U3j9z'
-    }
-}
+  data: {
+    sessionToken:
+      "3m3Q2h6e8T5w9t3W8b8y1F4t2m6Q9b8d9N6h1f2H2u0g6E7m9d9E3g7w3T3b5a7I4c4h6U4n2b3Z4p3j8D6p4a5G1c4a8K3o0v8P7e0j6R5i1y2J6d0c7N9i6m0U3j9z"
+  }
+};
 
 export const getWallets = (): WalletListResponse => {
-    const validCreditCard: { [key: string]: any } = {
-        id: 1464,
-        holder: "Mario Rossi",
-        pan: "************0111",
-        expireMonth: "05",
-        expireYear: "22",
-        brandLogo:
-          "https://wisp2.pagopa.gov.it/wallet/assets/img/creditcard/carta_mc.png",
-        flag3dsVerified: true
-    };
-  
-    const validAmount: { [key: string]: any } = {
-        currency: "EUR",
-        amount: 1000,
-        decimalDigits: 2
-    };
-  
-    const validPsp: { [key: string]: any } = {
-        id: 43188,
-        idPsp: "idPsp1",
-        businessName: "WHITE bank",
-        paymentType: "CP",
-        idIntermediary: "idIntermediario1",
-        idChannel: "idCanale14",
-        logoPSP:
-          "https://wisp2.pagopa.gov.it/pp-restapi/v2/resources/psp/1578833",
-        serviceLogo:
-          "https://wisp2.pagopa.gov.it/pp-restapi/v2/resources/service/1578833",
-        serviceName: "nomeServizio 10 white",
-        fixedCost: validAmount,
-        appChannel: false,
-        tags: ["MAESTRO"],
-        serviceDescription: "DESCRIZIONE servizio: CP mod1",
-        serviceAvailability: "DISPONIBILITA servizio 24/7",
-        paymentModel: 1,
-        flagStamp: true,
-        idCard: 91,
-        lingua: "IT"
-    };
+  const validCreditCard: { [key: string]: any } = {
+    id: 1464,
+    holder: "Mario Rossi",
+    pan: "************0111",
+    expireMonth: "05",
+    expireYear: "22",
+    brandLogo:
+      "https://wisp2.pagopa.gov.it/wallet/assets/img/creditcard/carta_mc.png",
+    flag3dsVerified: true
+  };
 
-    enum TypeEnum {
-        "CREDIT_CARD" = "CREDIT_CARD",
-        "BANK_ACCOUNT" = "BANK_ACCOUNT",
-        "EXTERNAL_PS" = "EXTERNAL_PS"
-    };
-  
-    const WalletCard: Wallet = {
+  const validAmount: { [key: string]: any } = {
+    currency: "EUR",
+    amount: 1000,
+    decimalDigits: 2
+  };
+
+  const validPsp: { [key: string]: any } = {
+    id: 43188,
+    idPsp: "idPsp1",
+    businessName: "WHITE bank",
+    paymentType: "CP",
+    idIntermediary: "idIntermediario1",
+    idChannel: "idCanale14",
+    logoPSP: "https://wisp2.pagopa.gov.it/pp-restapi/v2/resources/psp/1578833",
+    serviceLogo:
+      "https://wisp2.pagopa.gov.it/pp-restapi/v2/resources/service/1578833",
+    serviceName: "nomeServizio 10 white",
+    fixedCost: validAmount,
+    appChannel: false,
+    tags: ["MAESTRO"],
+    serviceDescription: "DESCRIZIONE servizio: CP mod1",
+    serviceAvailability: "DISPONIBILITA servizio 24/7",
+    paymentModel: 1,
+    flagStamp: true,
+    idCard: 91,
+    lingua: "IT"
+  };
+
+  const WalletCard: Wallet = {
+    idWallet: 12345,
+    type: TypeEnum.CREDIT_CARD,
+    favourite: false,
+    creditCard: validCreditCard as CreditCard,
+    psp: validPsp as Psp,
+    idPsp: validPsp.id,
+    pspEditable: true,
+    lastUsage: new Date("2018-08-07T15:50:08Z")
+  };
+
+  // It is displayed as card!
+  const WalletBank: Wallet = {
+    idWallet: 67890,
+    type: TypeEnum.CREDIT_CARD,
+    creditCard: validCreditCard as CreditCard,
+    psp: validPsp as Psp,
+    idPsp: validPsp.id,
+    pspEditable: true,
+    lastUsage: new Date("2018-08-07T15:50:08Z")
+  };
+
+  const data = {
+    data: [WalletBank, WalletCard]
+  };
+
+  return validatePayload(WalletListResponse, data);
+};
+
+export const getTransactions = (count: number): TransactionListResponse => {
+  const data: TransactionListResponse = {
+    data: range(1, count).map(idx => {
+      return {
+        accountingStatus: 1,
+        amount: { amount: 20000 },
+        created: new Date(2018, 10, 30, 13, 12, 22, 30),
+        description: `Transaction n.${idx}`,
+        error: false,
+        fee: { amount: 1 },
+        grandTotal: { amount: 32100 },
+        id: idx,
+        idPayment: 1,
+        idPsp: 43188,
+        idStatus: 3,
         idWallet: 12345,
-        type: TypeEnum.CREDIT_CARD,
-        favourite: false,
-        creditCard: validCreditCard as CreditCard,
-        psp: validPsp as Psp,
-        idPsp: validPsp.id,
-        pspEditable: true,
-        lastUsage: new Date("2018-08-07T15:50:08Z")
-    };
-  
-    // It is displayed as card!
-    const WalletBank: Wallet = {
-        idWallet: 67890,
-        type: TypeEnum.CREDIT_CARD,
-        creditCard: validCreditCard as CreditCard,
-        psp: validPsp as Psp,
-        idPsp: validPsp.id,
-        pspEditable: true,
-        lastUsage: new Date("2018-08-07T15:50:08Z")
-    };
-  
-    const data = {
-        data: [WalletBank, WalletCard]
-    };
-    
-    return validatePayload(WalletListResponse, data)
-
-}
-
-export const getTransactions = (count: number): TransactionListResponse => {    
-    const data: TransactionListResponse = {
-        data: range(1, count).map(_ => {
-            return ({
-                accountingStatus: 1,
-                amount: {amount: 20000},
-                created: new Date(2018,10,30,13,12,22,30),
-                description: `transaction n.${_}`,
-                error: false,
-                fee: {amount: 1},
-                grandTotal: {amount: 20100},
-                id: getRandomIntId(5),
-                idPayment: 1,
-                idPsp: 43188,
-                idStatus: 3,
-                idWallet: 12345,
-                merchant: 'merchant',
-                nodoIdPayment: 'nodoIdPayment' ,
-                paymentModel: 5,
-                spcNodeDescription: 'spcNodeDescription',
-                spcNodeStatus: 6,
-                statusMessage: 'statusMessage',
-                success: true,
-                token: 'token',
-                updated: undefined,
-                urlCheckout3ds: 'urlCheckout3ds',
-                urlRedirectPSP: 'urlRedirectPSP'
-            })
-        })
-    } 
-    return validatePayload(TransactionListResponse, data);
-}
+        merchant: "merchant",
+        nodoIdPayment: "nodoIdPayment",
+        paymentModel: 5,
+        spcNodeDescription: "spcNodeDescription",
+        spcNodeStatus: 6,
+        statusMessage: "statusMessage",
+        success: true,
+        token: "token",
+        updated: undefined,
+        urlCheckout3ds: "urlCheckout3ds",
+        urlRedirectPSP: "urlRedirectPSP"
+      };
+    })
+  };
+  return validatePayload(TransactionListResponse, data);
+};

--- a/payloads/wallet.ts
+++ b/payloads/wallet.ts
@@ -5,9 +5,9 @@ import { CreditCard } from "../generated/definitions/pagopa/CreditCard";
 import { Psp } from "../generated/definitions/pagopa/Psp";
 import { validatePayload } from "../src/utils/validator";
 import { SessionResponse } from "../generated/definitions/pagopa/SessionResponse";
-import { WalletResponse } from "../generated/definitions/pagopa/WalletResponse";
-import { TransactionResponse } from "../generated/definitions/pagopa/TransactionResponse";
 import { getRandomIntId } from "../src/utils/id";
+import { TransactionListResponse } from "../generated/definitions/pagopa/TransactionListResponse";
+import { WalletListResponse } from "../generated/definitions/pagopa/WalletListResponse";
 
 export const sessionToken: SessionResponse = {
     data: {
@@ -15,7 +15,7 @@ export const sessionToken: SessionResponse = {
     }
 }
 
-export const getWallets = (): WalletResponse => {
+export const getWallets = (): WalletListResponse => {
     const validCreditCard: { [key: string]: any } = {
         id: 1464,
         holder: "Mario Rossi",
@@ -84,19 +84,22 @@ export const getWallets = (): WalletResponse => {
         lastUsage: new Date("2018-08-07T15:50:08Z")
     };
   
-    return {
+    const data = {
         data: [WalletBank, WalletCard]
-    } ;   
+    };
+    
+    return validatePayload(WalletListResponse, data)
+
 }
 
-export const getTransactions = (amount: number): TransactionResponse => {
-    return {
-        data: range(1, amount).map(_ => {
+export const getTransactions = (count: number): TransactionListResponse => {    
+    const data: TransactionListResponse = {
+        data: range(1, count).map(_ => {
             return ({
                 accountingStatus: 1,
                 amount: {amount: 20000},
                 created: new Date(2018,10,30,13,12,22,30),
-                description: 'transaction n.' + _,
+                description: `transaction n.${_}`,
                 error: false,
                 fee: {amount: 1},
                 grandTotal: {amount: 20100},
@@ -116,7 +119,8 @@ export const getTransactions = (amount: number): TransactionResponse => {
                 updated: undefined,
                 urlCheckout3ds: 'urlCheckout3ds',
                 urlRedirectPSP: 'urlRedirectPSP'
-            });
+            })
         })
     } 
+    return validatePayload(TransactionListResponse, data);
 }

--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -6,8 +6,9 @@ import { InitializedProfile } from "../../generated/definitions/backend/Initiali
 import { UserMetadata } from "../../generated/definitions/backend/UserMetadata";
 import { UserProfile } from "../../generated/definitions/backend/UserProfile";
 import { basePath } from "../../generated/definitions/backend_api_paths";
-import app, { fiscalCode } from "../server";
 import { userMetadata } from "../../payloads/userMetadata";
+import app, { fiscalCode } from "../server";
+
 const request = supertest(app);
 
 it("profile should return a valid profile", async done => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,8 +16,8 @@ import { ResponseHandler } from "../payloads/response";
 import { getServiceMetadata, getServices } from "../payloads/service";
 import { session } from "../payloads/session";
 import { userMetadata } from "../payloads/userMetadata";
+import { getTransactions, getWallets, sessionToken } from "../payloads/wallet";
 import { validatePayload } from "./utils/validator";
-import { getWallets, getTransactions, sessionToken } from "../payloads/wallet";
 
 // fiscalCode used within the client communication
 export const fiscalCode = "RSSMRA83A12H501D";
@@ -61,11 +61,11 @@ app.get("/wallet/v1/users/actions/start-session", (_, res) => {
 });
 
 app.get("/wallet/v1/wallet", (_, res) => {
-  res.json(wallets)
-})
+  res.json(wallets);
+});
 
 app.get("/wallet/v1/transactions", (_, res) => {
-  res.json(transactions)
+  res.json(transactions);
 });
 
 /** static contents */

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { getServiceMetadata, getServices } from "../payloads/service";
 import { session } from "../payloads/session";
 import { userMetadata } from "../payloads/userMetadata";
 import { validatePayload } from "./utils/validator";
+import { getWallets, getTransactions, sessionToken } from "../payloads/wallet";
 
 // fiscalCode used within the client communication
 export const fiscalCode = "RSSMRA83A12H501D";
@@ -51,6 +52,21 @@ app.get("/ping", (_, res) => {
 
 export const messages = getMessageWithoutContentList(10, fiscalCode);
 export const services = getServices(10);
+export const wallets = getWallets();
+export const transactions = getTransactions(5);
+
+/** wallet content */
+app.get("/wallet/v1/users/actions/start-session", (_, res) => {
+  res.json(sessionToken)
+});
+
+app.get("/wallet/v1/wallet", (_, res) => {
+  res.json(wallets)
+})
+
+app.get("/wallet/v1/transactions", (_, res) => {
+  res.json(transactions)
+});
 
 /** static contents */
 app.get("/static_contents/services/:service_id", (req, res) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,7 @@ export const transactions = getTransactions(5);
 
 /** wallet content */
 app.get("/wallet/v1/users/actions/start-session", (_, res) => {
-  res.json(sessionToken)
+  res.json(sessionToken);
 });
 
 app.get("/wallet/v1/wallet", (_, res) => {

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,20 @@
+/**
+ * generate a n chars pseudo-random string (n value is 26 as default)
+ */
+export const getRandomStringId = (chars: number = 26): string => {
+    const randomSlice = () =>
+      Math.random()
+        .toString(36)
+        .substring(2, 15);
+    return (randomSlice() + randomSlice() + randomSlice())
+      .substring(0, chars)
+      .toUpperCase();
+  };
+
+/**
+ * generate a n chars pseudo-random integer number
+ */
+export const getRandomIntId = (length: number) => {
+    const num = Math.random() * 10^length;
+    return Math.floor(num)
+}

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -2,19 +2,19 @@
  * generate a n chars pseudo-random string (n value is 26 as default)
  */
 export const getRandomStringId = (chars: number = 26): string => {
-    const randomSlice = () =>
-      Math.random()
-        .toString(36)
-        .substring(2, 15);
-    return (randomSlice() + randomSlice() + randomSlice())
-      .substring(0, chars)
-      .toUpperCase();
-  };
+  const randomSlice = () =>
+    Math.random()
+      .toString(36)
+      .substring(2, 15);
+  return (randomSlice() + randomSlice() + randomSlice())
+    .substring(0, chars)
+    .toUpperCase();
+};
 
 /**
  * generate a n chars pseudo-random integer number
  */
 export const getRandomIntId = (length: number) => {
-    const num = Math.random() * 10^length;
-    return Math.floor(num)
-}
+  const num = Math.pow(Math.random() * 10, length);
+  return Math.floor(num);
+};


### PR DESCRIPTION
This pr introduces mocked wallets and transactions to display in the Wallet Home of IO app.

<img width="253" alt="image" src="https://user-images.githubusercontent.com/38431762/71882671-34f94300-3135-11ea-88cb-d58743a2904c.png">
