### PR TITLE
Update jest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "generate:models": "rimraf generated && rimraf generated/definitions/backend && mkdir -p generated/definitions/backend && gen-api-models --api-spec $npm_package_api_beckend_specs --out-dir ./generated/definitions/backend --no-strict --request-types && gen-api-models --api-spec $npm_package_api_public_specs --out-dir generated/definitions/backend",
     "generate:all": "npm-run-all generate:models generate:content-definitions generate:paths"
   },
+  "jest": {
+    "preset": "ts-jest"
+  },
   "dependencies": {
     "@types/body-parser": "^1.17.1",
     "@types/morgan": "^1.7.37",
@@ -46,3 +49,4 @@
     "typescript": "^3.7.3"
   }
 }
+


### PR DESCRIPTION
This pr apply 2 changes:
- remove the empty file "jest.config.json"
- add the rule  `"preset": "ts-jest" ` within the package file (being a short rule, I preferred to introduce it in `package.json` instead of in a `jest.config.js` file to avoid other changes to the `.gitignore` file - that currently ignore all .js files)

Without these changes, just importing the repo a half of the tests fail.