### PR TITLE
Remove services metadata as static content

### DIFF
--- a/src/payloads/service.ts
+++ b/src/payloads/service.ts
@@ -84,6 +84,7 @@ export const getServices = (count: number): readonly ServicePublic[] => {
         organization_name: `${faker.company.companyName()} [${organizationCount +
           1}]` as OrganizationName,
         service_metadata: {
+          ...getServiceMetadata(scope),
           scope,
           cta: frontMatter2CTA2 as NonEmptyString
         }
@@ -112,24 +113,12 @@ export const getServicesTuple = (
   return { payload, isJson: true };
 };
 
-export const getServiceMetadata = (
-  serviceId: string,
-  services: PaginatedServiceTupleCollection
-): IOResponse<ServicePublicService_metadata> => {
-  const serviceIndex = services.items.findIndex(
-    s => s.service_id === serviceId
-  );
-  // tslint:disable-next-line: no-let
-  let serviceScope: ServiceScopeEnum = ServiceScopeEnum.NATIONAL;
-  // first half -> LOCAL
-  // second half -> NATIONAL
-  if (serviceIndex + 1 <= services.items.length * 0.5) {
-    serviceScope = ServiceScopeEnum.LOCAL;
-  }
-
-  const metaData: ServicePublicService_metadata = {
+const getServiceMetadata = (
+  scope: ServiceScopeEnum
+): ServicePublicService_metadata => {
+  return {
     description: "demo demo <br/>demo demo <br/>demo demo <br/>demo demo <br/>" as NonEmptyString,
-    scope: serviceScope,
+    scope,
     address: faker.address.streetAddress() as NonEmptyString,
     email: faker.internet.email() as NonEmptyString,
     pec: faker.internet.email() as NonEmptyString,
@@ -139,10 +128,6 @@ export const getServiceMetadata = (
     app_ios: faker.internet.url() as NonEmptyString,
     tos_url: faker.internet.url() as NonEmptyString,
     privacy_url: faker.internet.url() as NonEmptyString
-  };
-  return {
-    payload: validatePayload(ServicePublicService_metadata, metaData),
-    isJson: true
   };
 };
 

--- a/src/payloads/service.ts
+++ b/src/payloads/service.ts
@@ -17,7 +17,10 @@ import {
 } from "../../generated/definitions/backend/ServicePublic";
 import { ServiceScopeEnum } from "../../generated/definitions/backend/ServiceScope";
 import { validatePayload } from "../utils/validator";
-import { frontMatter2CTA2 } from "../utils/variables";
+import {
+  frontMatter1CTASiciliaVola,
+  frontMatter2CTA2
+} from "../utils/variables";
 import { IOResponse } from "./response";
 
 export const getService = (serviceId: string): ServicePublic => {
@@ -36,31 +39,6 @@ export const getService = (serviceId: string): ServicePublic => {
   return validatePayload(ServicePublic, service);
 };
 
-export const siciliaVolaServiceId = "serviceSv";
-const siciliaVolaService: ServicePublic = {
-  ...getService(siciliaVolaServiceId),
-  organization_name: "Sicilia Vola" as OrganizationName,
-  service_name: "Sicilia Vola" as ServiceName,
-  service_metadata: {
-    scope: ServiceScopeEnum.NATIONAL
-  }
-};
-
-export const withSiciliaVolaService = (
-  services: readonly ServicePublic[]
-): readonly ServicePublic[] => {
-  const organizationsCount = new Set(
-    services.map(s => s.organization_fiscal_code)
-  ).size;
-  return services.concat({
-    ...siciliaVolaService,
-    organization_fiscal_code: `${organizationsCount + 1}`.padStart(
-      11,
-      "0"
-    ) as OrganizationFiscalCode
-  });
-};
-
 const getServiceMetadata = (
   scope: ServiceScopeEnum
 ): ServicePublicService_metadata => {
@@ -77,6 +55,32 @@ const getServiceMetadata = (
     tos_url: faker.internet.url() as NonEmptyString,
     privacy_url: faker.internet.url() as NonEmptyString
   };
+};
+
+export const siciliaVolaServiceId = "serviceSv";
+const siciliaVolaService: ServicePublic = {
+  ...getService(siciliaVolaServiceId),
+  organization_name: "Sicilia Vola" as OrganizationName,
+  service_name: "Sicilia Vola" as ServiceName,
+  service_metadata: {
+    ...getServiceMetadata(ServiceScopeEnum.NATIONAL),
+    cta: frontMatter1CTASiciliaVola as NonEmptyString
+  }
+};
+
+export const withSiciliaVolaService = (
+  services: readonly ServicePublic[]
+): readonly ServicePublic[] => {
+  const organizationsCount = new Set(
+    services.map(s => s.organization_fiscal_code)
+  ).size;
+  return services.concat({
+    ...siciliaVolaService,
+    organization_fiscal_code: `${organizationsCount + 1}`.padStart(
+      11,
+      "0"
+    ) as OrganizationFiscalCode
+  });
 };
 
 export const getServices = (count: number): readonly ServicePublic[] => {

--- a/src/payloads/service.ts
+++ b/src/payloads/service.ts
@@ -61,6 +61,24 @@ export const withSiciliaVolaService = (
   });
 };
 
+const getServiceMetadata = (
+  scope: ServiceScopeEnum
+): ServicePublicService_metadata => {
+  return {
+    description: "demo demo <br/>demo demo <br/>demo demo <br/>demo demo <br/>" as NonEmptyString,
+    scope,
+    address: faker.address.streetAddress() as NonEmptyString,
+    email: faker.internet.email() as NonEmptyString,
+    pec: faker.internet.email() as NonEmptyString,
+    phone: faker.phone.phoneNumber() as NonEmptyString,
+    web_url: faker.internet.url() as NonEmptyString,
+    app_android: faker.internet.url() as NonEmptyString,
+    app_ios: faker.internet.url() as NonEmptyString,
+    tos_url: faker.internet.url() as NonEmptyString,
+    privacy_url: faker.internet.url() as NonEmptyString
+  };
+};
+
 export const getServices = (count: number): readonly ServicePublic[] => {
   const aggregation = 3;
   // services belong to the same organization for blocks of `aggregation` size
@@ -111,24 +129,6 @@ export const getServicesTuple = (
     page_size: items.length
   });
   return { payload, isJson: true };
-};
-
-const getServiceMetadata = (
-  scope: ServiceScopeEnum
-): ServicePublicService_metadata => {
-  return {
-    description: "demo demo <br/>demo demo <br/>demo demo <br/>demo demo <br/>" as NonEmptyString,
-    scope,
-    address: faker.address.streetAddress() as NonEmptyString,
-    email: faker.internet.email() as NonEmptyString,
-    pec: faker.internet.email() as NonEmptyString,
-    phone: faker.phone.phoneNumber() as NonEmptyString,
-    web_url: faker.internet.url() as NonEmptyString,
-    app_android: faker.internet.url() as NonEmptyString,
-    app_ios: faker.internet.url() as NonEmptyString,
-    tos_url: faker.internet.url() as NonEmptyString,
-    privacy_url: faker.internet.url() as NonEmptyString
-  };
 };
 
 export const getServicesPreferences = (

--- a/src/routers/services_metadata.ts
+++ b/src/routers/services_metadata.ts
@@ -16,6 +16,9 @@ export const servicesMetadataRouter = Router();
 
 const addRoutePrefix = (path: string) => `${staticContentRootPath}${path}`;
 
+/**
+ * @deprecated the app should not use this API. It should consume metadata contained in the service detail
+ */
 addHandler(
   servicesMetadataRouter,
   "get",

--- a/src/routers/services_metadata.ts
+++ b/src/routers/services_metadata.ts
@@ -3,45 +3,18 @@
  */
 import { Router } from "express";
 import { readableReport } from "italia-ts-commons/lib/reporters";
-import { NonEmptyString } from "italia-ts-commons/lib/strings";
-import { ServicePublicService_metadata } from "../../generated/definitions/backend/ServicePublic";
 import { CoBadgeServices } from "../../generated/definitions/pagopa/cobadge/configuration/CoBadgeServices";
 import { PrivativeServices } from "../../generated/definitions/pagopa/privative/configuration/PrivativeServices";
 import { assetsFolder, staticContentRootPath } from "../global";
 import { backendStatus } from "../payloads/backend";
 import { municipality } from "../payloads/municipality";
-import { addHandler, IOResponse } from "../payloads/response";
-import { getServiceMetadata, siciliaVolaServiceId } from "../payloads/service";
+import { addHandler } from "../payloads/response";
 import { readFileAsJSON, sendFile } from "../utils/file";
-import { frontMatter1CTASiciliaVola } from "../utils/variables";
-import { services, visibleServices } from "./service";
+import { services } from "./service";
 
 export const servicesMetadataRouter = Router();
 
 const addRoutePrefix = (path: string) => `${staticContentRootPath}${path}`;
-
-const servicesMetadata: ReadonlyArray<ServicePublicService_metadata> = services.map(
-  service =>
-    getServiceMetadata(service.service_id, visibleServices.payload).payload
-);
-const servicesMetadataMapping: Record<
-  string,
-  ServicePublicService_metadata
-> = servicesMetadata.reduce(
-  (acc: Record<string, ServicePublicService_metadata>, curr, idx) => {
-    if (services[idx].service_id === siciliaVolaServiceId) {
-      return {
-        ...acc,
-        [services[idx].service_id.toLowerCase()]: {
-          ...curr,
-          cta: frontMatter1CTASiciliaVola as NonEmptyString
-        }
-      };
-    }
-    return { ...acc, [services[idx].service_id.toLowerCase()]: curr };
-  },
-  {}
-);
 
 addHandler(
   servicesMetadataRouter,
@@ -49,8 +22,12 @@ addHandler(
   addRoutePrefix(`/services/:service_id`),
   (req, res) => {
     const serviceId = req.params.service_id.split(".")[0];
-
-    res.json(servicesMetadataMapping[serviceId]);
+    const service = services.find(s => s.service_id === serviceId);
+    if (service === undefined || service.service_metadata === undefined) {
+      res.sendStatus(404);
+      return;
+    }
+    res.json(service.service_metadata);
   }
 );
 


### PR DESCRIPTION
This PR removes the API to serve service metadata as static content and it adds metadata into the service payload