### PR TITLE
[IAI-77] There should be no 'next' when the messages are over

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -74,7 +74,8 @@ const defaultConfig: IoDevServerConfig = {
     withEUCovidCert: false,
     withValidDueDateCount: 0,
     withInValidDueDateCount: 0,
-    standardMessageCount: 1,
+    // sending 2 messages at minimum to allow for basic pagination
+    standardMessageCount: 2,
     // it has no effect (pr welcome)
     allowRandomValues: true
   },

--- a/src/routers/message.ts
+++ b/src/routers/message.ts
@@ -327,11 +327,15 @@ addHandler(messageRouter, "get", addApiV1Prefix("/messages"), (req, res) => {
     res.json({ items: [] });
     return;
   }
+
   const slice = _.slice(orderedList, indexes.startIndex, indexes.endIndex);
+
   res.json({
     items: getItems(slice, params.enrichResultData!),
     prev: orderedList[indexes.startIndex]?.id,
-    next: slice[slice.length - 1]?.id
+    next: orderedList[indexes.endIndex]
+      ? slice[slice.length - 1]?.id
+      : undefined
   });
 });
 


### PR DESCRIPTION
Add test and refactor a bit, send 2 messages by default.

The actual fix is [a one liner](https://github.com/pagopa/io-dev-api-server/compare/IAI-77-fix-next-parameter-in-messages?expand=1#diff-c4cdb7cf0e69ecfc696d0ba80b8411dd4297658be4a57dad5f0954d7a9ae6d74R336) though I wanted to add a test for it and ended up dirtier than expected.