### PR TITLE
Remove redundant scripts and logic for test login

### DIFF
--- a/assets/html/login.html
+++ b/assets/html/login.html
@@ -73,14 +73,6 @@
             const select = `<select id="spidSelect" style="width: 400px;height: 40px;font-size: 20px">${options}</select>`;
             const container = document.getElementById("select_container");
             container.innerHTML = `<div>${select}</div>`;
-
-          if (window.__ENV_E2E_LOGIN_HAPPY_PATH__) {
-            setTimeout(() => {
-              // we want to simulate user's interaction as much as possible
-              const link = document.getElementById("login-link")
-              link.click()
-            }, 250)
-          }
         }
 
     </script>

--- a/configure.sh
+++ b/configure.sh
@@ -1,7 +1,0 @@
-set -euxo pipefail
-
-echo "Configuring the dev API server based on environment variables"
-
-# we add the prefix 'window.' to avoid runtime errors due to undeclared variables
-
-sed -i'.bak' -e "s/window.__ENV_E2E_LOGIN_HAPPY_PATH__/${ENV_E2E_LOGIN_HAPPY_PATH:-false}/g" assets/html/login.html

--- a/src/routers/message.ts
+++ b/src/routers/message.ts
@@ -6,6 +6,7 @@ import { __, match, not } from "ts-pattern";
 import { CreatedMessageWithContent } from "../../generated/definitions/backend/CreatedMessageWithContent";
 import { EUCovidCert } from "../../generated/definitions/backend/EUCovidCert";
 import { PrescriptionData } from "../../generated/definitions/backend/PrescriptionData";
+import { PublicMessage } from "../../generated/definitions/backend/PublicMessage";
 import { ioDevServerConfig } from "../config";
 import { getProblemJson } from "../payloads/error";
 import {
@@ -27,11 +28,6 @@ import {
 } from "../utils/variables";
 import { eucovidCertAuthResponses } from "./features/eu_covid_cert";
 import { services } from "./service";
-import { PublicMessage } from "../../generated/definitions/backend/PublicMessage";
-import * as t from "io-ts";
-import { FiscalCode } from "../../generated/definitions/backend/FiscalCode";
-import { Timestamp } from "../../generated/definitions/backend/Timestamp";
-import { ServiceId } from "../../generated/definitions/backend/ServiceId";
 
 export const messageRouter = Router();
 const configResponse = ioDevServerConfig.messages.response;


### PR DESCRIPTION
Now we can use `globals.autoLogin` in `config/config.json` instead.