### PR TITLE
Support payment config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -86,7 +86,7 @@ const defaultConfig: IoDevServerConfig = {
     attivaError: undefined,
     // it has no effect (pr welcome)
     allowRandomValues: true,
-    payment: {}
+    payment: undefined
   },
   services: {
     response: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,7 +85,8 @@ const defaultConfig: IoDevServerConfig = {
     verificaError: undefined,
     attivaError: undefined,
     // it has no effect (pr welcome)
-    allowRandomValues: true
+    allowRandomValues: true,
+    payment: {}
   },
   services: {
     response: {

--- a/src/payloads/payload.ts
+++ b/src/payloads/payload.ts
@@ -1,5 +1,6 @@
 import faker from "faker/locale/it";
 import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
+
 import { CodiceContestoPagamento } from "../../generated/definitions/backend/CodiceContestoPagamento";
 import { Iban } from "../../generated/definitions/backend/Iban";
 import { ImportoEuroCents } from "../../generated/definitions/backend/ImportoEuroCents";
@@ -14,7 +15,9 @@ import { PaymentResponse } from "../../generated/definitions/pagopa/walletv2/Pay
 import { LinguaEnum } from "../../generated/definitions/pagopa/walletv2/Psp";
 import { PspListResponseCD as PspListResponse } from "../../generated/definitions/pagopa/walletv2/PspListResponseCD";
 import { PspResponse } from "../../generated/definitions/pagopa/walletv2/PspResponse";
+
 import { ioDevServerConfig } from "../config";
+import { getRandomValue } from "../utils/random";
 import { validatePayload } from "../utils/validator";
 
 import { validPsp } from "./wallet";
@@ -250,13 +253,15 @@ export const transactionIdResponseSecond = {
 export const getPaymentRequestsGetResponse = (
   senderService: ServicePublic
 ): PaymentRequestsGetResponse => ({
-  importoSingoloVersamento:
-    (ioDevServerConfig.wallet.payment
-      .amount as PaymentRequestsGetResponse["importoSingoloVersamento"]) ??
-    (faker.datatype.number({
+  importoSingoloVersamento: getRandomValue(
+    ioDevServerConfig.wallet.payment
+      ?.amount as PaymentRequestsGetResponse["importoSingoloVersamento"],
+    faker.datatype.number({
       min: 1,
       max: 9999
-    }) as PaymentRequestsGetResponse["importoSingoloVersamento"]),
+    }) as PaymentRequestsGetResponse["importoSingoloVersamento"],
+    "wallet"
+  ),
   codiceContestoPagamento: faker.random.alphaNumeric(
     32
   ) as PaymentRequestsGetResponse["codiceContestoPagamento"],

--- a/src/payloads/payload.ts
+++ b/src/payloads/payload.ts
@@ -14,7 +14,9 @@ import { PaymentResponse } from "../../generated/definitions/pagopa/walletv2/Pay
 import { LinguaEnum } from "../../generated/definitions/pagopa/walletv2/Psp";
 import { PspListResponseCD as PspListResponse } from "../../generated/definitions/pagopa/walletv2/PspListResponseCD";
 import { PspResponse } from "../../generated/definitions/pagopa/walletv2/PspResponse";
+import { ioDevServerConfig } from "../config";
 import { validatePayload } from "../utils/validator";
+
 import { validPsp } from "./wallet";
 
 type settings = {
@@ -248,10 +250,13 @@ export const transactionIdResponseSecond = {
 export const getPaymentRequestsGetResponse = (
   senderService: ServicePublic
 ): PaymentRequestsGetResponse => ({
-  importoSingoloVersamento: faker.datatype.number({
-    min: 1,
-    max: 9999
-  }) as PaymentRequestsGetResponse["importoSingoloVersamento"],
+  importoSingoloVersamento:
+    (ioDevServerConfig.wallet.payment
+      .amount as PaymentRequestsGetResponse["importoSingoloVersamento"]) ??
+    (faker.datatype.number({
+      min: 1,
+      max: 9999
+    }) as PaymentRequestsGetResponse["importoSingoloVersamento"]),
   codiceContestoPagamento: faker.random.alphaNumeric(
     32
   ) as PaymentRequestsGetResponse["codiceContestoPagamento"],

--- a/src/payloads/wallet.ts
+++ b/src/payloads/wallet.ts
@@ -1,6 +1,7 @@
 import * as faker from "faker/locale/it";
 import { range } from "fp-ts/lib/Array";
 import { fromNullable } from "fp-ts/lib/Option";
+
 import { CreditCard } from "../../generated/definitions/pagopa/walletv2/CreditCard";
 import {
   LinguaEnum,
@@ -13,9 +14,10 @@ import {
   Wallet
 } from "../../generated/definitions/pagopa/walletv2/Wallet";
 import { WalletListResponse } from "../../generated/definitions/pagopa/walletv2/WalletListResponse";
+
+import { ioDevServerConfig } from "../config";
 import { creditCardBrands, getCreditCardLogo } from "../utils/payment";
 import { getRandomValue } from "../utils/random";
-import { ioDevServerConfig } from "../config";
 import { validatePayload } from "../utils/validator";
 
 export const sessionToken: SessionResponse = {
@@ -24,8 +26,11 @@ export const sessionToken: SessionResponse = {
   }
 };
 const getAmount = () =>
-  ioDevServerConfig.wallet.payment.fee ??
-  getRandomValue(1000, faker.datatype.number({ min: 1, max: 150 }), "wallet");
+  getRandomValue(
+    ioDevServerConfig.wallet.payment?.pspFeeAmount,
+    faker.datatype.number({ min: 1, max: 150 }),
+    "wallet"
+  );
 
 export const validPsp: Psp = {
   id: 40000,

--- a/src/payloads/wallet.ts
+++ b/src/payloads/wallet.ts
@@ -15,6 +15,7 @@ import {
 import { WalletListResponse } from "../../generated/definitions/pagopa/walletv2/WalletListResponse";
 import { creditCardBrands, getCreditCardLogo } from "../utils/payment";
 import { getRandomValue } from "../utils/random";
+import { ioDevServerConfig } from "../config";
 import { validatePayload } from "../utils/validator";
 
 export const sessionToken: SessionResponse = {
@@ -23,7 +24,9 @@ export const sessionToken: SessionResponse = {
   }
 };
 const getAmount = () =>
+  ioDevServerConfig.wallet.payment.fee ??
   getRandomValue(1000, faker.datatype.number({ min: 1, max: 150 }), "wallet");
+
 export const validPsp: Psp = {
   id: 40000,
   idPsp: "idPsp1",

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -46,6 +46,13 @@ export const WalletMethodConfig = t.interface({
 });
 export type WalletMethodConfig = t.TypeOf<typeof WalletMethodConfig>;
 
+export const PaymentConfig = t.partial({
+  // integer including decimals - ie: 22.22 = 2222
+  amount: t.number,
+  fee: t.number
+});
+export type PaymentConfig = t.TypeOf<typeof PaymentConfig>;
+
 /* general http response codes */
 const HttpResponseCode = t.union([
   t.literal(200),
@@ -141,7 +148,9 @@ export const IoDevServerConfig = t.interface({
       // if false fixed values will be used
       allowRandomValues: t.boolean,
       methods: WalletMethodConfig,
-      shuffleAbi: t.boolean
+      shuffleAbi: t.boolean,
+      // configure the dummy payment
+      payment: PaymentConfig
     }),
     t.partial({
       // if defined attiva will serve the given error
@@ -149,6 +158,7 @@ export const IoDevServerConfig = t.interface({
       // if verifica attiva will serve the given error
       verificaError: enumType<Detail_v2Enum>(Detail_v2Enum, "detail_v2")
     }),
+
     AllowRandomValue
   ])
 });

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,7 +3,9 @@ import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import * as t from "io-ts";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { enumType } from "italia-ts-commons/lib/types";
+
 import { EmailAddress } from "../../generated/definitions/backend/EmailAddress";
+import { ImportoEuroCents } from "../../generated/definitions/backend/ImportoEuroCents";
 import { Detail_v2Enum } from "../../generated/definitions/backend/PaymentProblemJson";
 import { PreferredLanguages } from "../../generated/definitions/backend/PreferredLanguages";
 
@@ -46,10 +48,10 @@ export const WalletMethodConfig = t.interface({
 });
 export type WalletMethodConfig = t.TypeOf<typeof WalletMethodConfig>;
 
-export const PaymentConfig = t.partial({
+export const PaymentConfig = t.interface({
   // integer including decimals - ie: 22.22 = 2222
-  amount: t.number,
-  fee: t.number
+  amount: ImportoEuroCents,
+  pspFeeAmount: t.number
 });
 export type PaymentConfig = t.TypeOf<typeof PaymentConfig>;
 
@@ -148,15 +150,15 @@ export const IoDevServerConfig = t.interface({
       // if false fixed values will be used
       allowRandomValues: t.boolean,
       methods: WalletMethodConfig,
-      shuffleAbi: t.boolean,
-      // configure the dummy payment
-      payment: PaymentConfig
+      shuffleAbi: t.boolean
     }),
     t.partial({
       // if defined attiva will serve the given error
       attivaError: enumType<Detail_v2Enum>(Detail_v2Enum, "detail_v2"),
       // if verifica attiva will serve the given error
-      verificaError: enumType<Detail_v2Enum>(Detail_v2Enum, "detail_v2")
+      verificaError: enumType<Detail_v2Enum>(Detail_v2Enum, "detail_v2"),
+      // configure the dummy payment
+      payment: PaymentConfig
     }),
 
     AllowRandomValue

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -15,7 +15,8 @@ const getValueGlobalRandomOn: RandomValueFunc = <T>(
   randomValue: T,
   configSectionKey: AllorRandomValueKeys
 ) =>
-  ioDevServerConfig[configSectionKey].allowRandomValues
+  ioDevServerConfig[configSectionKey].allowRandomValues ||
+  defaultValue === undefined
     ? randomValue
     : defaultValue;
 


### PR DESCRIPTION
The new config under `wallet.payment` is defined [here](https://github.com/pagopa/io-dev-api-server/compare/IAI-85-payment-config?expand=1#diff-fea291e6a68bacafef88ed99be7ad4916267ab6585b42401f1f76ddcbb37706aR52). 

It will allow us to test the full payment journey with deterministic values.