### PR TITLE
[IA-544] Align backendStatus to io-services-metadata

### DIFF
--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -192,6 +192,9 @@ export const backendStatus: BackendStatus = {
     },
     bpd_ranking: true,
     bpd_ranking_v2: true,
-    cgn_merchants_v2: false
+    cgn_merchants_v2: false,
+    zendesk: {
+      active: false
+    }
   }
 };


### PR DESCRIPTION
This PR fix a bug introduced with pagopa/io-services-metadata#522 aligning the backendStatus response to the specs in _io-services-metadata_