### PR TITLE
Fix payment manager wallet type

### DIFF
--- a/src/payloads/wallet_v2.ts
+++ b/src/payloads/wallet_v2.ts
@@ -310,14 +310,10 @@ export const generateWalletV2FromPaypal = (
   };
 };
 
-export const generateWalletV1FromPayPal = (
-  idWallet: number,
-  info: PayPalInfo
-): Wallet => ({
+export const generateWalletV1FromPayPal = (idWallet: number): Wallet => ({
   idWallet,
   type: WalletV1TypeEnum.EXTERNAL_PS,
   favourite: false,
-  payPals: [info],
   pspEditable: true,
   isPspToIgnore: false,
   saved: false,

--- a/src/routers/wallet.ts
+++ b/src/routers/wallet.ts
@@ -74,7 +74,7 @@ const convertFavouriteWalletfromV2V1 = (
       generateWalletV1FromCardInfo(wallet.idWallet!, wallet.info as CardInfo)
     )
     .with(WalletTypeEnum.PayPal, () =>
-      generateWalletV1FromPayPal(wallet.idWallet!, wallet.info as PayPalInfo)
+      generateWalletV1FromPayPal(wallet.idWallet!)
     )
     .otherwise(() => undefined);
 };


### PR DESCRIPTION
This PR update the `generateWalletV1FromPayPal` payload and the `convertFavouriteWalletfromV2V1` util according to the new [spec.json](https://raw.githubusercontent.com/pagopa/io-app/30acad7ebe51088d97b33f503fffc8673ab0d585/assets/paymentManager/spec.json)  