### PR TITLE
Add MVL without html every 2 messages

### DIFF
--- a/src/payloads/message.ts
+++ b/src/payloads/message.ts
@@ -58,10 +58,14 @@ export const withDueDate = (
   return { ...message, content: { ...message.content, due_date: dueDate } };
 };
 
+/**
+ * Add the MVL payload to a generic message.
+ */
 export const withLegalContent = (
   message: CreatedMessageWithContent,
   mvlMsgId: string,
-  attachments: ReadonlyArray<Attachment> = []
+  attachments: ReadonlyArray<Attachment> = [],
+  hasHtml: boolean = true
 ): LegalMessageWithContent => {
   // helper functions
   const getEmail = (hardCodedEmail: string) =>
@@ -75,7 +79,7 @@ export const withLegalContent = (
     eml: {
       subject: getWords("You're fired"),
       plain_text_content: getWords("lol I'm joking!"),
-      html_content: getWords("<p>or <b>am I?</b></p>"),
+      html_content: hasHtml ? getWords("<p>or <b>am I?</b></p>") : "",
       attachments
     },
     cert_data: {

--- a/src/routers/message.ts
+++ b/src/routers/message.ts
@@ -272,10 +272,14 @@ const createMessages = (): Array<
   );
 
   range(1, ioDevServerConfig.messages.legalCount).forEach((count, idx) => {
-    const message = getNewMessage(`⚖️ Legal - ${count} `, messageMarkdown);
+    const isOdd = count % 2 > 0;
+    const message = getNewMessage(
+      `⚖️ Legal -${isOdd ? "" : "without HTML"} ${count}`,
+      messageMarkdown
+    );
     const mvlMsgId = message.id;
     const attachments = getMvlAttachments(mvlMsgId, ["pdf", "png"]);
-    output.push(withLegalContent(message, message.id, attachments));
+    output.push(withLegalContent(message, message.id, attachments, isOdd));
   });
 
   return output;


### PR DESCRIPTION
This PR will let the server return an empty string in the HTML body of an MVL. Useful for testing.