### PR TITLE
[IAMVL-69] Use messageId for attachments

### DIFF
--- a/src/routers/message.ts
+++ b/src/routers/message.ts
@@ -472,11 +472,9 @@ addHandler(
   "get",
   addApiV1Prefix("/legal-messages/:legalMessageId/attachments/:attachmentId"),
   (req, res) => {
-    // find the message by the given legalID
+    // find the message by the given legalMessageID
     const message = messagesWithContent.find(
-      ld =>
-        (ld as LegalMessageWithContent).legal_message?.cert_data.data
-          .envelope_id === req.params.legalMessageId
+      ld => ld.id === req.params.legalMessageId
     );
     const legalMessage = LegalMessageWithContent.decode(message);
     // ensure message exists and it has a legal content


### PR DESCRIPTION
As per [the latest specs](https://github.com/pagopa/io-backend/pull/864/files#diff-ac5f41902728c87f4277af9405ffbdf02ba3225a7987805c9b9603119e691e7bR323).

Match against `message.id` instead of the `envelope_id` property.