### PR TITLE
chore: Update backend response with production value

### DIFF
--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -217,7 +217,7 @@ export const backendStatus: BackendStatus = {
     bpd_ranking_v2: true,
     cgn_merchants_v2: false,
     assistanceTool: {
-      tool: ToolEnum.instabug
+      tool: ToolEnum.zendesk
     },
     paypal: {
       enabled: true


### PR DESCRIPTION
This pr sync the `assistanceTool.tool` with `zendesk` in order to mirror the production response.