### PR TITLE
Send attachment.size for >1 attachment

### DIFF
--- a/src/payloads/message.ts
+++ b/src/payloads/message.ts
@@ -210,7 +210,8 @@ export const getMvlAttachments = (
         name: parsedFile.base,
         content_type:
           contentTypeMapping[parsedFile.ext.substr(1)] ?? defaultContentType,
-        url: attachmentUrl
+        url: attachmentUrl,
+        size: idx > 0 ? idx * 100000 : undefined
       };
     }
   });


### PR DESCRIPTION
## Short description
Send the optional `size` parameter starting from the 2nd attachment in the list.

## How to test
1. run the app with `MVL=yes` and set `legalCount: 2` for the server
2. tap on one of the MVL in the list
3. notice the sice is now shown for the second and third attachments