### PR TITLE
[IA-662] Update delete-wallets api

### DIFF
--- a/src/routers/__tests__/wallets.test.ts
+++ b/src/routers/__tests__/wallets.test.ts
@@ -146,6 +146,7 @@ it("should remove in bulk all these methods that have a specific function enable
     if (E.isRight(deleteResponse) && deleteResponse.value.data) {
       expect(deleteResponse.value.data.deletedWallets).toBe(toBeDeleted);
       expect(deleteResponse.value.data.notDeletedWallets).toBe(0);
+      expect(deleteResponse.value.data.remainingWallets).toBe([]);
     }
     testResponse(pagopaWallets.length, response);
     testResponse(bpdWallets.length, responseBpd);

--- a/src/routers/walletsV2/index.ts
+++ b/src/routers/walletsV2/index.ts
@@ -271,7 +271,8 @@ addHandler(
     const response: DeletedWalletsResponse = {
       data: {
         deletedWallets: deletedWallets.length,
-        notDeletedWallets: walletsToDelete.length - deletedWallets.length
+        notDeletedWallets: walletsToDelete.length - deletedWallets.length,
+        remainingWallets: getWalletV2()
       }
     };
     res.json(response);


### PR DESCRIPTION
## This PR depends on https://github.com/pagopa/io-app/pull/3743
## Short description
Update the `/delete-wallets` endpoint adding the `remainingWallets` field in the response.

## List of changes proposed in this pull request
- adding the `remainingWallets` field in the `/delete-wallets` response.
- update test

## How to test
Run the tests suite
