### PR TITLE
[IA-771] Sync the dev-server with the new Premium Messages configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "api_cgn": "https://raw.githubusercontent.com/pagopa/io-backend/v7.37.0-RELEASE/api_cgn.yaml",
   "api_cgn_merchants": "https://raw.githubusercontent.com/pagopa/io-backend/v7.37.0-RELEASE/api_cgn_operator_search.yaml",
   "api_cgn_geo": "https://raw.githubusercontent.com/pagopa/io-backend/here_geoapi_integration/api_geo.yaml",
-  "content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.8/definitions.yml",
+  "content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.9/definitions.yml",
   "api_pagopa_walletv2": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.6/bonus/specs/bpd/pm/walletv2.json",
   "api_pagopa": "https://raw.githubusercontent.com/pagopa/io-app/master/assets/paymentManager/spec.json",
   "pagopa_cobadge_configuration": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.6/pagopa/cobadge/abi_definitions.yml",

--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -250,6 +250,9 @@ export const backendStatus: BackendStatus = {
     },
     fims: {
       enabled: false
+    },
+    premiumMessages: {
+      opt_in_out_enabled: false
     }
   }
 };


### PR DESCRIPTION
## Short description
This PR is going to sync the development server with the new Premium Messages configuration from `io-services-metadata` added through https://github.com/pagopa/io-services-metadata/pull/600.

## List of changes proposed in this pull request
- Upgrade the `io-services-metadata` package used for the specs to `1.0.9`
- Add a `premiumMessages` configuration inside `backend.ts`

## How to test
👀
