### PR TITLE
[AP-16] Cdc endpoint

### DIFF
--- a/assets/cdc/CdcSwagger.yml
+++ b/assets/cdc/CdcSwagger.yml
@@ -1,0 +1,173 @@
+info:
+  title: Carta della Cultutra REST APIs
+  description: API to request Carta della Cultura
+  version: 0.0.1
+paths:
+  /beneficiario/stato:
+    get:
+      summary: Lettura stato beneficiario per ogni anno
+      operationId: getStatoBeneficiario
+      responses:
+        '200':
+          description: Stato Beneficiario per Anno
+          schema:
+            $ref: '#/definitions/ListaStatoPerAnno'
+        '401':
+          description: Utente non autorizzato
+        '403':
+          description: Utente non loggato
+        '404':
+          description: Risorsa non trovata
+        '500':
+          description: Errore interno.
+      security:
+        - BearerAuth: []
+      parameters: []
+      produces:
+        - application/json
+  /beneficiario/registrazione:
+    post:
+      tags:
+        - /secured/utente
+      summary: Richiesta Carta della Cultura da parte del beneficiario
+      operationId: registraBeneficiario
+      responses:
+        '200':
+          description: Richiesta OK per almeno un anno
+          schema:
+            $ref: '#/definitions/ListaEsitoRichiestaPerAnno'
+        '400':
+          description: Validazioni non superate
+          schema:
+            $ref: '#/definitions/RichiestaCartaErrata'
+        '401':
+          description: Utente non autorizzato
+        '403':
+          description: Utente non loggato
+        '404':
+          description: Risorsa non esiste
+        '500':
+          description: Errore interno.
+      security:
+        - BearerAuth: []
+      parameters:
+        - required: true
+          name: body
+          in: body
+          schema:
+            $ref: '#/definitions/AnniRiferimento'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+swagger: '2.0'
+basePath: /$%7Bhost%7D
+definitions:
+  StatoBeneficiario:
+    type: string
+    enum:
+      - ATTVABILE
+      - INATTIVABILE
+      - ATTIVO
+      - VALUTAZIONE
+      - INATTIVO
+  EsitoRichiesta:
+    type: string
+    enum:
+      - INIZIATIVA_TERMINATA
+      - ANNO_NON_AMMISSIBILE
+      - CIT_REGISTRATO
+  Anno:
+    type: string
+    pattern: ^\\d{4}$
+    description: Anno a quattro cifre
+    example: '2000'
+  AnnoIsee:
+    type: object
+    required:
+      - anno
+    properties:
+      anno:
+        $ref: '#/definitions/Anno'
+      dataIsee:
+        type: string
+  RichiestaCartaErrataMotivo:
+    type: string
+    enum:
+      - NO_INPUT
+      - ANNI_RIFERIMENTO_NON_FORNITI
+      - LISTA_ANNI_VUOTA
+      - FORMATO_ANNI_ERRATO
+  RichiestaCartaErrata:
+    type: object
+    required:
+      - annoRiferimento
+      - status
+    properties:
+      type:
+        type: string
+      annoRiferimento:
+        $ref: '#/definitions/Anno'
+      title:
+        type: string
+      status:
+        $ref: '#/definitions/RichiestaCartaErrataMotivo'
+      detail:
+        type: string
+      instance:
+        type: string
+      errorCode:
+        type: string
+  StatoBeneficiarioPerAnno:
+    type: object
+    required:
+      - statoBeneficiario
+      - annoRiferimento
+    properties:
+      statoBeneficiario:
+        $ref: '#/definitions/StatoBeneficiario'
+      annoRiferimento:
+        $ref: '#/definitions/Anno'
+  EsitoRichiestaPerAnno:
+    type: object
+    required:
+      - statoBeneficiario
+      - annoRiferimento
+    properties:
+      statoBeneficiario:
+        $ref: '#/definitions/EsitoRichiesta'
+      annoRiferimento:
+        $ref: '#/definitions/Anno'
+  ListaStatoPerAnno:
+    type: object
+    required:
+      - listaStatoPerAnno
+    properties:
+      listaStatoPerAnno:
+        type: array
+        items:
+          $ref: '#/definitions/StatoBeneficiarioPerAnno'
+  ListaEsitoRichiestaPerAnno:
+    type: object
+    required:
+      - listaEsitoRichiestaPerAnno
+    properties:
+      listaEsitoRichiestaPerAnno:
+        type: array
+        items:
+          $ref: '#/definitions/EsitoRichiestaPerAnno'
+  AnniRiferimento:
+    type: object
+    required:
+      - anniRif
+    properties:
+      anniRif:
+        type: array
+        items:
+          $ref: '#/definitions/AnnoIsee'
+securityDefinitions:
+  BearerAuth:
+    type: apiKey
+    name: Authorization
+    in: header
+x-components: {}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "api_bpd_winning_transactions_v2": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.12/bonus/specs/bpd/winning_transactions_v2.json",
   "api_eu_covid_cert": "https://raw.githubusercontent.com/pagopa/io-backend/v7.37.0-RELEASE/api_eucovidcert.yaml",
   "api_sicilia_vola": "assets/SiciliaVola.yml",
+  "api_cdc": "assets/cdc/CdcSwagger.yml",
   "author": "Matteo Boschi",
   "license": "MIT",
   "private": false,
@@ -53,7 +54,8 @@
     "generate:bpd-winning-transactions-v2": "rimraf generated/definitions/bpd/winning_transactions/v2 && mkdir -p generated/definitions/bpd/winning_transactions/v2  && gen-api-models --api-spec $npm_package_api_bpd_winning_transactions_v2 --out-dir ./generated/definitions/bpd/winning_transactions/v2 --no-strict",
     "generate:eu-covid-cert-definitions": "rimraf generated/definitions/eu_covid_cert && mkdir -p generated/definitions/eu_covid_cert && gen-api-models --api-spec $npm_package_api_eu_covid_cert --out-dir ./generated/definitions/eu_covid_cert --no-strict",
     "generate:sicilia-vola-definitions": "rimraf generated/definitions/siciliaVola && mkdir -p generated/definitions/siciliaVola && gen-api-models --api-spec $npm_package_api_sicilia_vola --out-dir ./generated/definitions/siciliaVola --no-strict",
-    "generate:all": "npm-run-all generate:models generate:content-definitions generate:pagopa-api generate:pagopa-cobadge-configuration-definitions generate:pagopa-privative-configuration-definitions generate:bonus-vacanze-definitions generate:bpd-citizen generate:bpd-citizen-v2 generate:pagopa-walletv2-definitions generate:bpd-payment generate:bpd-award generate:bpd-winning-transactions generate:bpd-winning-transactions-v2 generate:cgn-definitions generate:cgn-merchants-definitions generate:cgn-geo-definitions generate:eu-covid-cert-definitions generate:sicilia-vola-definitions"
+    "generate:cdc-definitions": "rimraf generated/definitions/cdc && mkdir -p generated/definitions/cdc  && gen-api-models --api-spec $npm_package_api_cdc --out-dir ./generated/definitions/cdc --no-strict",
+    "generate:all": "npm-run-all generate:models generate:content-definitions generate:pagopa-api generate:pagopa-cobadge-configuration-definitions generate:pagopa-privative-configuration-definitions generate:bonus-vacanze-definitions generate:bpd-citizen generate:bpd-citizen-v2 generate:pagopa-walletv2-definitions generate:bpd-payment generate:bpd-award generate:bpd-winning-transactions generate:bpd-winning-transactions-v2 generate:cgn-definitions generate:cgn-merchants-definitions generate:cgn-geo-definitions generate:eu-covid-cert-definitions generate:sicilia-vola-definitions generate:cdc-definitions"
   },
   "jest": {
     "preset": "ts-jest",

--- a/src/routers/features/cdc/bonusRequest.ts
+++ b/src/routers/features/cdc/bonusRequest.ts
@@ -93,6 +93,7 @@ addHandler(
           };
         }
 
+        // tslint:disable-next-line: no-object-mutation
         bonusStatusByYear[y.anno] = StatoBeneficiarioEnum.VALUTAZIONE;
 
         return {

--- a/src/routers/features/cdc/bonusRequest.ts
+++ b/src/routers/features/cdc/bonusRequest.ts
@@ -1,0 +1,114 @@
+import { Router } from "express";
+import * as E from "fp-ts/lib/Either";
+import { AnniRiferimento } from "../../../../generated/definitions/cdc/AnniRiferimento";
+import { Anno } from "../../../../generated/definitions/cdc/Anno";
+import { EsitoRichiestaEnum } from "../../../../generated/definitions/cdc/EsitoRichiesta";
+import { ListaEsitoRichiestaPerAnno } from "../../../../generated/definitions/cdc/ListaEsitoRichiestaPerAnno";
+import { ListaStatoPerAnno } from "../../../../generated/definitions/cdc/ListaStatoPerAnno";
+import { StatoBeneficiarioEnum } from "../../../../generated/definitions/cdc/StatoBeneficiario";
+import { addHandler } from "../../../payloads/response";
+
+export const cdcBonusRequestRouter = Router();
+
+const generateBonusAll = (): ListaStatoPerAnno => {
+  return {
+    listaStatoPerAnno: [
+      {
+        annoRiferimento: "2020" as Anno,
+        statoBeneficiario: StatoBeneficiarioEnum.ATTVABILE
+      },
+      {
+        annoRiferimento: "2021" as Anno,
+        statoBeneficiario: StatoBeneficiarioEnum.ATTVABILE
+      },
+      {
+        annoRiferimento: "2022" as Anno,
+        statoBeneficiario: StatoBeneficiarioEnum.ATTVABILE
+      }
+    ]
+  };
+};
+
+// TODO: update the prefix when will be official
+const addPrefix = (path: string) => `${path}`;
+
+// tslint:disable-next-line: no-let
+let bonusAll: ListaStatoPerAnno = generateBonusAll();
+
+addHandler(
+  cdcBonusRequestRouter,
+  "get",
+  addPrefix("/beneficiario/stato"),
+  (req, res) => {
+    return res.status(200).json(bonusAll);
+  }
+);
+
+addHandler(
+  cdcBonusRequestRouter,
+  "post",
+  addPrefix("/beneficiario/registrazione"),
+  (req, res) => {
+    const maybeAnniRiferimento = AnniRiferimento.decode(req.body);
+    if (E.isLeft(maybeAnniRiferimento)) {
+      res.sendStatus(500);
+      return;
+    }
+
+    const anniRiferimento = maybeAnniRiferimento.value.anniRif;
+
+    const bonusStatusByYear = Object.assign(
+      {},
+      ...bonusAll.listaStatoPerAnno.map(x => ({
+        [x.annoRiferimento]: x.statoBeneficiario
+      }))
+    );
+
+    const listaEsitoRichiestaPerAnno: ListaEsitoRichiestaPerAnno = {
+      listaEsitoRichiestaPerAnno: anniRiferimento.map(y => {
+        if (
+          bonusStatusByYear[y.anno] === undefined ||
+          bonusStatusByYear[y.anno] === StatoBeneficiarioEnum.INATTIVO
+        ) {
+          return {
+            annoRiferimento: y.anno,
+            statoBeneficiario: EsitoRichiestaEnum.ANNO_NON_AMMISSIBILE
+          };
+        }
+
+        if (bonusStatusByYear[y.anno] === StatoBeneficiarioEnum.INATTIVABILE) {
+          return {
+            annoRiferimento: y.anno,
+            statoBeneficiario: EsitoRichiestaEnum.INIZIATIVA_TERMINATA
+          };
+        }
+
+        if (
+          bonusStatusByYear[y.anno] === StatoBeneficiarioEnum.ATTIVO ||
+          bonusStatusByYear[y.anno] === StatoBeneficiarioEnum.VALUTAZIONE
+        ) {
+          return {
+            annoRiferimento: y.anno,
+            statoBeneficiario: EsitoRichiestaEnum.CIT_REGISTRATO
+          };
+        }
+
+        bonusStatusByYear[y.anno] = StatoBeneficiarioEnum.VALUTAZIONE;
+
+        return {
+          annoRiferimento: y.anno,
+          statoBeneficiario: EsitoRichiestaEnum.CIT_REGISTRATO
+        };
+      })
+    };
+
+    bonusAll = {
+      listaStatoPerAnno: bonusAll.listaStatoPerAnno.map(s => ({
+        ...s,
+        statoBeneficiario: bonusStatusByYear[s.annoRiferimento]
+      }))
+    };
+
+    return res.status(200).json(listaEsitoRichiestaPerAnno);
+  }
+);

--- a/src/routers/features/cdc/index.ts
+++ b/src/routers/features/cdc/index.ts
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { cdcBonusRequestRouter } from "./bonusRequest";
+
+export const cdcRouter = Router();
+
+cdcRouter.use(cdcBonusRequestRouter);

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { bpdRankingV2 } from "./routers/features/bdp/ranking/v2";
 import { bpdWinningTransactionsV1 } from "./routers/features/bdp/winning-transactions/v1";
 import { bpdWinningTransactionsV2 } from "./routers/features/bdp/winning-transactions/v2";
 import { bonusVacanze } from "./routers/features/bonus-vacanze";
+import { cdcRouter } from "./routers/features/cdc";
 import { cgnRouter } from "./routers/features/cgn";
 import { cgnGeoRouter } from "./routers/features/cgn/geocoding";
 import { cgnMerchantsRouter } from "./routers/features/cgn/merchants";
@@ -77,7 +78,8 @@ app.use(errorMiddleware);
   cgnMerchantsRouter,
   cgnGeoRouter,
   euCovidCertRouter,
-  svRouter
+  svRouter,
+  cdcRouter
 ].forEach(r => app.use(r));
 
 export default app;


### PR DESCRIPTION
## Short description
This PR adds the endpoints for the Cdc project

## List of changes proposed in this pull request
- Added the `GET /beneficiario/stato`
- Added the `POST /beneficiario/registrazione`
- Temporary added the locally the swagger

## How to test
Test suite is included.
To test manually invoke the endpoints:
- The GET don't want any parameters
- For the POST send in the body a payload of type `AnniRiferimento` for example:
```typescript
    {
      anniRif: [
        { anno: "2019" as Anno },
        { anno: "2020" as Anno },
        { anno: "2022" as Anno }
      ]
    }
```