### PR TITLE
[AP-29] Add cdc service and bonus metadata

### DIFF
--- a/assets/bonus_available/bonus_available_v2.json
+++ b/assets/bonus_available/bonus_available_v2.json
@@ -129,8 +129,8 @@
     "visibility": "hidden",
     "valid_from": "2020-07-01T00:00:00.000Z",
     "valid_to": "2020-12-31T00:00:00.000Z",
-    "cover": "https://assets.cdn.io.italia.it/bonus/cgn/logo/logo-cgn.png",
+    "cover": "https://assets.cdn.io.italia.it/bonus/cdc/logo/logo-cdc.png",
     "sponsorship_description": "PCM - Dipartimento per le Politiche Giovanili e il Servizio Civile Universale",
-    "sponsorship_cover": "https://assets.cdn.io.italia.it/bonus/cgn/logo/logo-cgn.png"
+    "sponsorship_cover": "https://assets.cdn.io.italia.it/bonus/cdc/logo/logo-cdc.png"
   }
 ]

--- a/assets/bonus_available/bonus_available_v2.json
+++ b/assets/bonus_available/bonus_available_v2.json
@@ -110,14 +110,14 @@
   {
     "id_type": 4,
     "it": {
-      "name": "Carta Della Cultura ",
+      "name": "Carta Della Cultura",
       "description": "Carta Della Cultura (CDC) è l’incentivo per i giovani che favorisce la partecipazione ad attività culturali, sportive e ricreative, su tutto il territorio nazionale",
       "subtitle": "Carta Della Cultura (CDC) è l’incentivo per i giovani che favorisce la partecipazione ad attività culturali, sportive e ricreative, su tutto il territorio nazionale",
       "title": "Attiva la Carta Della Cultura",
       "content": ""
     },
     "en": {
-      "name": "Carta Giovani Nazionale",
+      "name": "Carta Della Cultura",
       "description": "Carta della Cultura (CDC) is an incentive for young people to participate in cultural, sporting and recreational activities throughout the country",
       "subtitle": "Carta della Cultura (CDC) is an incentive for young people to participate in cultural, sporting and recreational activities throughout the country",
       "title": "Activate the Carta della Cultura",
@@ -125,8 +125,8 @@
     },
     "hidden": false,
     "service_id": "01G2AFTME08TS0QD2P2S682CJ0",
-    "is_active": false,
-    "visibility": "hidden",
+    "is_active": true,
+    "visibility": "visible",
     "valid_from": "2020-07-01T00:00:00.000Z",
     "valid_to": "2020-12-31T00:00:00.000Z",
     "cover": "https://assets.cdn.io.italia.it/bonus/cdc/logo/logo-cdc.png",

--- a/assets/bonus_available/bonus_available_v2.json
+++ b/assets/bonus_available/bonus_available_v2.json
@@ -106,5 +106,31 @@
     "cover": "https://assets.cdn.io.italia.it/bonus/cgn/logo/logo-cgn.png",
     "sponsorship_description": "PCM - Dipartimento per le Politiche Giovanili e il Servizio Civile Universale",
     "sponsorship_cover": "https://assets.cdn.io.italia.it/bonus/cgn/logo/logo-cgn.png"
+  },
+  {
+    "id_type": 4,
+    "it": {
+      "name": "Carta Della Cultura ",
+      "description": "Carta Della Cultura (CDC) è l’incentivo per i giovani che favorisce la partecipazione ad attività culturali, sportive e ricreative, su tutto il territorio nazionale",
+      "subtitle": "Carta Della Cultura (CDC) è l’incentivo per i giovani che favorisce la partecipazione ad attività culturali, sportive e ricreative, su tutto il territorio nazionale",
+      "title": "Attiva la Carta Della Cultura",
+      "content": ""
+    },
+    "en": {
+      "name": "Carta Giovani Nazionale",
+      "description": "Carta della Cultura (CDC) is an incentive for young people to participate in cultural, sporting and recreational activities throughout the country",
+      "subtitle": "Carta della Cultura (CDC) is an incentive for young people to participate in cultural, sporting and recreational activities throughout the country",
+      "title": "Activate the Carta della Cultura",
+      "content": ""
+    },
+    "hidden": false,
+    "service_id": "01G2AFTME08TS0QD2P2S682CJ0",
+    "is_active": false,
+    "visibility": "hidden",
+    "valid_from": "2020-07-01T00:00:00.000Z",
+    "valid_to": "2020-12-31T00:00:00.000Z",
+    "cover": "https://assets.cdn.io.italia.it/bonus/cgn/logo/logo-cgn.png",
+    "sponsorship_description": "PCM - Dipartimento per le Politiche Giovanili e il Servizio Civile Universale",
+    "sponsorship_cover": "https://assets.cdn.io.italia.it/bonus/cgn/logo/logo-cgn.png"
   }
 ]

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,6 +112,7 @@ const defaultConfig: IoDevServerConfig = {
     local: 5,
     includeSiciliaVola: true,
     includeCgn: true,
+    includeCdc: true,
     // it has partially effect (pr welcome)
     allowRandomValues: true
   },

--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -261,7 +261,7 @@ export const backendStatus: BackendStatus = {
       opt_in_out_enabled: false
     },
     cdc: {
-      enabled: false
+      enabled: true
     },
     barcodesScanner: {
       dataMatrixPosteEnabled: false

--- a/src/payloads/services/special.ts
+++ b/src/payloads/services/special.ts
@@ -80,7 +80,7 @@ const specialServicesFactory: ReadonlyArray<readonly [
 ]> = [
   [ioDevServerConfig.services.includeSiciliaVola, withSiciliaVolaService],
   [ioDevServerConfig.services.includeCgn, withCgnService],
-  [true, withCdcService]
+  [ioDevServerConfig.services.includeCdc, withCdcService]
 ];
 
 // eventually add the special services based on config flags

--- a/src/payloads/services/special.ts
+++ b/src/payloads/services/special.ts
@@ -53,6 +53,25 @@ const withCgnService = (
   organization_fiscal_code: organizationFiscalCode
 });
 
+export const cdcServiceId = "01G2AFTME08TS0QD2P2S682CJ0";
+const cdcService: ServicePublic = {
+  ...getService(cdcServiceId),
+  organization_name: "Ministero beni culturali" as OrganizationName,
+  service_name: "Carta Della Cultura" as ServiceName,
+  service_metadata: {
+    ...getServiceMetadata(ServiceScopeEnum.NATIONAL),
+    category: SpecialServiceCategoryEnum.SPECIAL,
+    custom_special_flow: "cdc" as SpecialServiceMetadata["custom_special_flow"]
+  }
+};
+
+const withCdcService = (
+  organizationFiscalCode: OrganizationFiscalCode
+): ServicePublic => ({
+  ...cdcService,
+  organization_fiscal_code: organizationFiscalCode
+});
+
 // list of tuple where the first element is a flag indicating if the relative service should be included
 // the second element is the service factory
 const specialServicesFactory: ReadonlyArray<readonly [
@@ -60,7 +79,8 @@ const specialServicesFactory: ReadonlyArray<readonly [
   (organizationFiscalCode: OrganizationFiscalCode) => ServicePublic
 ]> = [
   [ioDevServerConfig.services.includeSiciliaVola, withSiciliaVolaService],
-  [ioDevServerConfig.services.includeCgn, withCgnService]
+  [ioDevServerConfig.services.includeCgn, withCgnService],
+  [true, withCdcService]
 ];
 
 // eventually add the special services based on config flags

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -178,7 +178,8 @@ export const IoDevServerConfig = t.interface({
       // number of services local
       local: t.number,
       includeSiciliaVola: t.boolean,
-      includeCgn: t.boolean
+      includeCgn: t.boolean,
+      includeCdc: t.boolean
     }),
     AllowRandomValue
   ]),


### PR DESCRIPTION
## Short description
This PR adds the CDC special service and the CDC to the available bonus metadata.
Note that the bonus metadata is filled with fake data and is at the moment not created in production.

