### PR TITLE
[IAI-203] Fix the Payment Manager types conflicts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
           name: Generate models
           command: yarn generate:all
       - run:
+          name: Run compilation
+          command: yarn tsc:noemit
+      - run:
           name: Run linter
           command: yarn tslint --config tslint.json -p tsconfig.json
       - run:

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lint-autofix": "tslint -p . -t verbose --fix",
     "start": "ts-node src/start.ts",
     "prettify": "prettier --write \"src/**/*.ts*\"",
+    "tsc:noemit": "tsc --noEmit",
     "generate:models": "rimraf generated && rimraf generated/definitions/backend && mkdir -p generated/definitions/backend && gen-api-models --api-spec $npm_package_api_backend_specs --out-dir ./generated/definitions/backend --no-strict && gen-api-models --api-spec $npm_package_api_public_specs --out-dir generated/definitions/backend",
     "generate:content-definitions": "rimraf generated/definitions/content && mkdir -p generated/definitions/content && gen-api-models --api-spec $npm_package_content_specs --out-dir ./generated/definitions/content",
     "generate:pagopa-cobadge-configuration-definitions": "rimraf generated/definitions/pagopa/cobadge/configuration && mkdir -p generated/definitions/pagopa/cobadge/configuration && gen-api-models --api-spec $npm_package_pagopa_cobadge_configuration --out-dir ./generated/definitions/pagopa/cobadge/configuration",

--- a/src/payloads/wallet.ts
+++ b/src/payloads/wallet.ts
@@ -3,13 +3,13 @@ import { range } from "fp-ts/lib/Array";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/pipeable";
 import { PspDataListResponse } from "../../generated/definitions/pagopa/PspDataListResponse";
+import { Transaction } from "../../generated/definitions/pagopa/Transaction";
 import { CreditCard } from "../../generated/definitions/pagopa/walletv2/CreditCard";
 import {
   LinguaEnum,
   Psp
 } from "../../generated/definitions/pagopa/walletv2/Psp";
 import { SessionResponse } from "../../generated/definitions/pagopa/walletv2/SessionResponse";
-import { Transaction } from "../../generated/definitions/pagopa/Transaction";
 import {
   TypeEnum,
   Wallet

--- a/src/payloads/wallet.ts
+++ b/src/payloads/wallet.ts
@@ -9,7 +9,7 @@ import {
   Psp
 } from "../../generated/definitions/pagopa/walletv2/Psp";
 import { SessionResponse } from "../../generated/definitions/pagopa/walletv2/SessionResponse";
-import { Transaction } from "../../generated/definitions/pagopa/walletv2/Transaction";
+import { Transaction } from "../../generated/definitions/pagopa/Transaction";
 import {
   TypeEnum,
   Wallet

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,6 +61,8 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Short description
This PR is going to fix a type conflict in the Payment Manager caused by https://github.com/pagopa/io-app/pull/3963

## List of changes proposed in this pull request
- Used the correct specs in `src/payloads/wallet.ts`
- Added a `tsc --noEmit` script in `package.json` and executed it on the CI to add a typecheck

