### PR TITLE
Sync the `accepted_tos_version` to `4.0`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ const defaultProfileAttrs: ProfileAttrs = {
   mobile: "5555555555" as NonEmptyString,
   fiscal_code: "TAMMRA80A41H501I" as FiscalCode,
   email: "maria.giovanna.rossi@email.it" as EmailAddress,
-  accepted_tos_version: 2.4 as NonNegativeNumber,
+  accepted_tos_version: 4.0 as NonNegativeNumber,
   preferred_languages: [PreferredLanguageEnum.it_IT]
 };
 


### PR DESCRIPTION
## Short description
This PR is going to sync the default `accepted_tos_version` in the dev server with the one bumped in https://github.com/pagopa/io-app/pull/4048. This will prevent the ToS screen to always appear while using the development environment.

## List of changes proposed in this pull request
- Bumped `accepted_tos_version` to `4.0`
