### PR TITLE
[IAI-249] Update README instructions to include API definitions generation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -23,6 +23,8 @@ The node version used in this project is stored in [.node-version](.node-version
 1. clone this repository
 1. install all packages needed:<br/>
    `yarn install`
+1. generate API definitions:
+   `yarn generate:all`
 1. you are ready! start the server:<br/>
    `yarn start`
 

--- a/README.MD
+++ b/README.MD
@@ -23,7 +23,7 @@ The node version used in this project is stored in [.node-version](.node-version
 1. clone this repository
 1. install all packages needed:<br/>
    `yarn install`
-1. generate API definitions:
+1. generate API definitions:<br/>
    `yarn generate:all`
 1. you are ready! start the server:<br/>
    `yarn start`


### PR DESCRIPTION
## Short description
This PR adds a missing instruction point to the Setup section in the README file. Such point is the API definition generation, after the `yarn install` command.

## List of changes proposed in this pull request
- Added the API definitions generation instruction and command on the SETUP section of the README file

## How to test
Follow the Setup process after repository cloning
