### PR TITLE
Bump io-services-metadata from 1.0.23 to 1.0.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "api_cgn": "https://raw.githubusercontent.com/pagopa/io-backend/v9.2.0-RELEASE/api_cgn.yaml",
   "api_cgn_merchants": "https://raw.githubusercontent.com/pagopa/io-backend/v9.2.0-RELEASE/api_cgn_operator_search.yaml",
   "api_cgn_geo": "https://raw.githubusercontent.com/pagopa/io-backend/here_geoapi_integration/api_geo.yaml",
-  "content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/IOAPPCIT-38-lollipop-ff-min-app-version/definitions.yml",
+  "content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.24/definitions.yml",
   "api_pagopa_walletv2": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.20/bonus/specs/bpd/pm/walletv2.json",
   "api_pagopa": "https://raw.githubusercontent.com/pagopa/io-app/master/assets/paymentManager/spec.json",
   "pagopa_cobadge_configuration": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.20/pagopa/cobadge/abi_definitions.yml",


### PR DESCRIPTION
## Short description
Bump io-services-metadata from 1.0.23 to 1.0.24

## List of changes proposed in this pull request
- package.json bump to io-services-metadata from 1.0.23 to 1.0.24

## How to test
Check CI checks for successful completion
