### PR TITLE
LolliPOP login: User-Agent and Hash Algorithm

### DIFF
--- a/src/routers/public.ts
+++ b/src/routers/public.ts
@@ -163,8 +163,8 @@ function checkLollipopUserAgentHader(
     return false;
   }
   const majorVersion = parseInt(userAgentMatches![1]);
-  var minorVersion = parseInt(userAgentMatches![2]);
-  var patchVersion = parseInt(userAgentMatches![3]);
+  const minorVersion = parseInt(userAgentMatches![2]);
+  const patchVersion = parseInt(userAgentMatches![3]);
   if (majorVersion < 2 || minorVersion < 23 || patchVersion < 0) {
     return false;
   }

--- a/src/utils/login.ts
+++ b/src/utils/login.ts
@@ -1,8 +1,9 @@
 export const getSamlRequest = (
-  id: string = "_2d2a89e99c7583e221b4"
+  algorithm: string = "sha256",
+  hash: string = "sha256-_2d2a89e99c7583e221b4"
 ) => `<?xml version="1.0"?>
 <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
-                    ID="${id}"
+                    ID="${algorithm}-${hash}"
                     Version="2.0"
                     IssueInstant="2023-01-20T10:03:42.600Z"
                     ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"


### PR DESCRIPTION
## Short description
This PR adds the User-Agent validation in the login flow when using LolliPOP and it also adds the HASH algorithm in the `SAMLRequest` query parameter

## List of changes proposed in this pull request
- `src/routers/public.ts` validates the User-Agent, both syntax and min app version
- `src/utils/login.ts` requires (and adds) the hash algorithm name when computing the `SAMLRequest` string

## How to test
Make an `HTTP` call to the `/login` endpoint with the 'x-pagopa-lollipop-pub-key' and 'x-pagopa-lollipop-pub-key-hash-algo' headers set.
Without the `User-Agent` header or a malformed one, the response should be an `400 Bad Request`. This also happens if the app version is less than `2.23.0`.
With a proper User-Agent header, like `IO-App/2.23.0`, the request should return a `302 Found` (watch out for automatically followed redirects in your client).
Also check that the `ID` in the `SAMLRequest` is in the format `{algorithmName}-{publicKeyHash}`
