### PR TITLE
[LLK-54] Remove LolliPoP header check during login

### DIFF
--- a/src/routers/public.ts
+++ b/src/routers/public.ts
@@ -51,16 +51,6 @@ addHandler(publicRouter, "get", "/login", async (req, res) => {
     return;
   }
 
-  const userAgent = req.get("user-agent") ?? "";
-  if (!checkLollipopUserAgent(userAgent)) {
-    res.status(400).json({
-      detail: "Wrong Lollipop UserAgent",
-      status: 400,
-      title: "Bad Request"
-    });
-    return;
-  }
-
   const jwkPK = parseJwkOrError(lollipopPublicKeyHeaderValue);
 
   if (E.isLeft(jwkPK) || !JwkPublicKey.is(jwkPK.right)) {
@@ -159,17 +149,6 @@ const handleLollipopLoginRedirect = (
   )}`;
   res.redirect(redirectUrl);
 };
-
-const checkLollipopUserAgent = (userAgent: string): boolean =>
-  pipe(
-    userAgent,
-    SemverFromFromUserAgentString.decode,
-    E.fold(
-      () => false,
-      userAgent =>
-        UserAgentSemverValid.equals(userAgent, ACCEPTED_LOLLIPOP_USER_AGENT)
-    )
-  );
 
 const debugSamlRequestIfNeeded = async (
   samlReq: string,


### PR DESCRIPTION
🤚 This PR depends on [137](https://github.com/pagopa/io-spid-commons/pull/137) 🤚

## Short description
This PR removes the check on the user-agent header during login with LolliPoP

## List of changes proposed in this pull request
- src/routes/public.ts: code related to user-agent check has been deleted

## How to test
Do a login with LolliPoP headers and no User-agent and check that it succeeds
