### PR TITLE
chore(Firma con IO): [SFEQS-1523] Add rejected and signed message

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -88,7 +88,8 @@ const defaultConfig: IoDevServerConfig = {
       rejectedCount: 0,
       expiredCount: 0,
       expired90Count: 0,
-      waitForQtspCount: 0
+      waitForQtspCount: 0,
+      signedCount: 0
     },
     withCTA: false,
     withEUCovidCert: false,

--- a/src/populate-persistence.ts
+++ b/src/populate-persistence.ts
@@ -37,7 +37,7 @@ import {
   frontMatterBonusVacanze,
   frontMatterCTAFCISignatureRequest,
   frontMatterCTAFCISignatureRequestExpired,
-  frontMatterCTAFCISignatureRequestSigned,
+  frontMatterCTAFCISignatureRequestRejected,
   frontMatterCTAFCISignatureRequestSignedExpired,
   frontMatterCTAFCISignatureRequestWaitQtsp,
   messageFciMarkdown,
@@ -290,8 +290,18 @@ const createMessages = (
         getNewMessage(
           customConfig,
           `Comune di Controguerra - Richiesta di Firma [REJECTED] - ${count} `,
-          frontMatterCTAFCISignatureRequestSignedExpired +
-            messageFciSignedMarkdown
+          frontMatterCTAFCISignatureRequestRejected + messageFciSignedMarkdown
+        )
+      );
+    });
+
+  customConfig.messages.fci.signedCount > 0 &&
+    range(1, customConfig.messages.fci.signedCount).forEach(count => {
+      output.push(
+        getNewMessage(
+          customConfig,
+          `Comune di Controguerra - Richiesta di Firma [SIGNED] - ${count} `,
+          frontMatterCTAFCISignatureRequest + messageFciSignedMarkdown
         )
       );
     });

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -166,7 +166,8 @@ export const IoDevServerConfig = t.interface({
         rejectedCount: t.number,
         expiredCount: t.number,
         expired90Count: t.number,
-        waitForQtspCount: t.number
+        waitForQtspCount: t.number,
+        signedCount: t.number
       }),
       // if true, messages (all available) with nested CTA will be included
       withCTA: t.boolean,

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -1,5 +1,6 @@
 import {
   EXPIRED_SIGNATURE_REQUEST_ID,
+  REJECTED_SIGNATURE_REQUEST_ID,
   SIGNATURE_REQUEST_ID,
   SIGNED_EXPIRED_SIGNATURE_REQUEST_ID,
   SIGNED_SIGNATURE_REQUEST_ID,
@@ -227,6 +228,17 @@ en:
     cta_1: 
         text: "Go to the documents"
         action: "ioit://fci/main?signatureRequestId=${WAIT_QTSP_SIGNATURE_REQUEST_ID}"
+---`;
+
+export const frontMatterCTAFCISignatureRequestRejected = `---
+it:
+    cta_1: 
+        text: "Visualizza i documenti"
+        action: "ioit://fci/main?signatureRequestId=${REJECTED_SIGNATURE_REQUEST_ID}"
+en:
+    cta_1: 
+        text: "View documents"
+        action: "ioit://fci/main?signatureRequestId=${REJECTED_SIGNATURE_REQUEST_ID}"
 ---`;
 
 export const frontMatterCTAFCISignatureRequestSigned = `---


### PR DESCRIPTION
## Short description
This PR adds rejected and signed message type to the dev-server config.

## List of changes proposed in this pull request
- Update config
- Update message generator

## How to test
Start dev-server using fci config.json as above:
`{
  "profile": {
    "attrs": {
      "name": "Gian Maria"
    }
  },
  "messages":{
    "fci": {
      "waitForSignatureCount": 1,
      "rejectedCount": 1,
      "expiredCount": 1,
      "expired90Count": 1,
      "waitForQtspCount": 1,
      "signedCount": 1
    }
  }
}`