### PR TITLE
[LLK-66] Added LP key verification support for login flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A mock server to help io-app development https://io.italia.it/",
   "version": "1.0.0",
   "main": "app.js",
-  "api_backend_specs": "https://raw.githubusercontent.com/pagopa/io-backend/IOCIT-374-assertion-ref-get-profile/api_backend.yaml",
+  "api_backend_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v10.5.0-RELEASE/api_backend.yaml",
   "api_public_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v9.13.1-RELEASE/api_public.yaml",
   "api_bonus_vacanze": "https://raw.githubusercontent.com/pagopa/io-backend/v9.13.1-RELEASE/api_bonus.yaml",
   "api_cgn": "https://raw.githubusercontent.com/pagopa/io-backend/v9.13.1-RELEASE/api_cgn.yaml",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A mock server to help io-app development https://io.italia.it/",
   "version": "1.0.0",
   "main": "app.js",
-  "api_backend_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v9.13.1-RELEASE/api_backend.yaml",
+  "api_backend_specs": "https://raw.githubusercontent.com/pagopa/io-backend/IOCIT-374-assertion-ref-get-profile/api_backend.yaml",
   "api_public_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v9.13.1-RELEASE/api_public.yaml",
   "api_bonus_vacanze": "https://raw.githubusercontent.com/pagopa/io-backend/v9.13.1-RELEASE/api_bonus.yaml",
   "api_cgn": "https://raw.githubusercontent.com/pagopa/io-backend/v9.13.1-RELEASE/api_cgn.yaml",

--- a/src/persistence/lollipop.ts
+++ b/src/persistence/lollipop.ts
@@ -1,17 +1,12 @@
-import { AssertionRef } from "../../generated/definitions/backend/AssertionRef"
-import { DEFAULT_LOLLIPOP_HASH_ALGORITHM } from "../routers/public"
+import { AssertionRef } from "../../generated/definitions/backend/AssertionRef";
+import { DEFAULT_LOLLIPOP_HASH_ALGORITHM } from "../routers/public";
 
-let lollipopAssertionRef: AssertionRef | undefined = undefined
+let lollipopAssertionRef: AssertionRef | undefined = undefined;
 
-
-export function getAssertionRef(){
-    return lollipopAssertionRef
+export function getAssertionRef() {
+  return lollipopAssertionRef;
 }
 
-export function setAssertionRef(key:string | undefined){
-    lollipopAssertionRef = `${DEFAULT_LOLLIPOP_HASH_ALGORITHM}-${key}` as AssertionRef
+export function setAssertionRef(key: string | undefined) {
+  lollipopAssertionRef = `${DEFAULT_LOLLIPOP_HASH_ALGORITHM}-${key}` as AssertionRef;
 }
-
-
-
-

--- a/src/persistence/lollipop.ts
+++ b/src/persistence/lollipop.ts
@@ -1,0 +1,17 @@
+import { AssertionRef } from "../../generated/definitions/backend/AssertionRef"
+import { DEFAULT_LOLLIPOP_HASH_ALGORITHM } from "../routers/public"
+
+let lollipop_assertion_ref: AssertionRef | undefined = undefined
+
+
+export function getAssertionRef(){
+    return lollipop_assertion_ref
+}
+
+export function setAssertionRef(key:string | undefined){
+    lollipop_assertion_ref = `${DEFAULT_LOLLIPOP_HASH_ALGORITHM}-${key}` as AssertionRef
+}
+
+
+
+

--- a/src/persistence/lollipop.ts
+++ b/src/persistence/lollipop.ts
@@ -1,15 +1,15 @@
 import { AssertionRef } from "../../generated/definitions/backend/AssertionRef"
 import { DEFAULT_LOLLIPOP_HASH_ALGORITHM } from "../routers/public"
 
-let lollipop_assertion_ref: AssertionRef | undefined = undefined
+let lollipopAssertionRef: AssertionRef | undefined = undefined
 
 
 export function getAssertionRef(){
-    return lollipop_assertion_ref
+    return lollipopAssertionRef
 }
 
 export function setAssertionRef(key:string | undefined){
-    lollipop_assertion_ref = `${DEFAULT_LOLLIPOP_HASH_ALGORITHM}-${key}` as AssertionRef
+    lollipopAssertionRef = `${DEFAULT_LOLLIPOP_HASH_ALGORITHM}-${key}` as AssertionRef
 }
 
 

--- a/src/routers/public.ts
+++ b/src/routers/public.ts
@@ -30,6 +30,7 @@ import { resetBonusVacanze } from "./features/bonus-vacanze";
 import { resetCgn } from "./features/cgn";
 import { resetProfile } from "./profile";
 import { resetWalletV2 } from "./walletsV2";
+import { setAssertionRef } from "../persistence/lollipop";
 
 export const publicRouter = Router();
 
@@ -62,6 +63,8 @@ addHandler(publicRouter, "get", "/login", async (req, res) => {
     jwkPK.right,
     DEFAULT_LOLLIPOP_HASH_ALGORITHM
   );
+
+  setAssertionRef(thumbprint);
 
   const samlRequest = getSamlRequest(
     DEFAULT_LOLLIPOP_HASH_ALGORITHM,

--- a/src/routers/session.ts
+++ b/src/routers/session.ts
@@ -2,12 +2,19 @@ import { Router } from "express";
 import faker from "faker/locale/it";
 import { addHandler } from "../payloads/response";
 import { session } from "../payloads/session";
+import { getAssertionRef } from "../persistence/lollipop";
 import { getRandomValue } from "../utils/random";
 import { addApiV1Prefix } from "../utils/strings";
 export const sessionRouter = Router();
 
 addHandler(sessionRouter, "get", addApiV1Prefix("/session"), (_, res) =>
-  res.json(session.payload)
+  {
+    const payload = {
+      ...session.payload,
+      lollipop_assertion_ref: getAssertionRef()
+    }
+    return res.json(payload)
+  }
 );
 
 addHandler(sessionRouter, "get", addApiV1Prefix("/token/support"), (_, res) =>
@@ -20,3 +27,4 @@ addHandler(sessionRouter, "get", addApiV1Prefix("/token/support"), (_, res) =>
     expires_in: getRandomValue(180, faker.datatype.number(), "global")
   })
 );
+

--- a/src/routers/session.ts
+++ b/src/routers/session.ts
@@ -11,7 +11,7 @@ addHandler(sessionRouter, "get", addApiV1Prefix("/session"), (_, res) =>
   {
     const payload = {
       ...session.payload,
-      lollipop_assertion_ref: getAssertionRef()
+      lollipopAssertionRef: getAssertionRef()
     }
     return res.json(payload)
   }

--- a/src/routers/session.ts
+++ b/src/routers/session.ts
@@ -7,15 +7,13 @@ import { getRandomValue } from "../utils/random";
 import { addApiV1Prefix } from "../utils/strings";
 export const sessionRouter = Router();
 
-addHandler(sessionRouter, "get", addApiV1Prefix("/session"), (_, res) =>
-  {
-    const payload = {
-      ...session.payload,
-      lollipopAssertionRef: getAssertionRef()
-    }
-    return res.json(payload)
-  }
-);
+addHandler(sessionRouter, "get", addApiV1Prefix("/session"), (_, res) => {
+  const payload = {
+    ...session.payload,
+    lollipopAssertionRef: getAssertionRef()
+  };
+  return res.json(payload);
+});
 
 addHandler(sessionRouter, "get", addApiV1Prefix("/token/support"), (_, res) =>
   res.json({
@@ -27,4 +25,3 @@ addHandler(sessionRouter, "get", addApiV1Prefix("/token/support"), (_, res) =>
     expires_in: getRandomValue(180, faker.datatype.number(), "global")
   })
 );
-


### PR DESCRIPTION
## Short description
Added LP key verification support for login flow

## List of changes proposed in this pull request
- package.json: updated backend api.
- src/persistence/lollipop.ts: added logic to store `lollipopAssertionRef`.
- src/routers/public.ts: added function to store `lollipopAssertionRef`.
- src/routers/session.ts: added to response payload `lollipopAssertionRef`.

## How to test
1) Try to send a login payload with a valid `lollipopPublicKeyHeaderValue` and verify if `lollipopAssertionRef` contains the right thumbprint value.
2) Try to `get session` and verify if `lollipopAssertionRef` is in response payload and contains the right value.