### PR TITLE
[IOAPPFD0-56] Add 404 status on service 4 logo

### DIFF
--- a/src/routers/services_metadata.ts
+++ b/src/routers/services_metadata.ts
@@ -4,6 +4,7 @@
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { Router } from "express";
 import * as E from "fp-ts/lib/Either";
+import * as B from "fp-ts/lib/boolean";
 import { pipe } from "fp-ts/lib/function";
 import { SpidIdps } from "../../generated/definitions/content/SpidIdps";
 import { VersionInfo } from "../../generated/definitions/content/VersionInfo";
@@ -67,15 +68,17 @@ addHandler(
   servicesMetadataRouter,
   "get",
   addRoutePrefix("/logos/organizations/:organization_id"),
-  (req, res) => {
-    if (req.params.organization_id === "4.png") {
-      // we send a 404 for the service number 4 to check missing image values
-      res.sendStatus(404);
-    } else {
-      // ignoring organization id and send always the same image
-      sendFile("assets/imgs/logos/organizations/organization_1.png", res);
-    }
-  }
+  (req, res) =>
+    pipe(
+      req.params.organization_id === "4.png",
+      B.fold(
+        // ignoring organization id and send always the same image
+        () =>
+          sendFile("assets/imgs/logos/organizations/organization_1.png", res),
+        // we send a 404 for the service number 4 to check missing image values
+        () => res.sendStatus(404)
+      )
+    )
 );
 
 addHandler(

--- a/src/routers/services_metadata.ts
+++ b/src/routers/services_metadata.ts
@@ -67,9 +67,14 @@ addHandler(
   servicesMetadataRouter,
   "get",
   addRoutePrefix("/logos/organizations/:organization_id"),
-  (_, res) => {
-    // ignoring organization id and send always the same image
-    sendFile("assets/imgs/logos/organizations/organization_1.png", res);
+  (req, res) => {
+    if (req.params.organization_id === "4.png") {
+      // we send a 404 for the service number 4 to check missing image values
+      res.sendStatus(404);
+    } else {
+      // ignoring organization id and send always the same image
+      sendFile("assets/imgs/logos/organizations/organization_1.png", res);
+    }
   }
 );
 


### PR DESCRIPTION
## Short description
This PR responds with a 404 error for the service nr. 4 logo HTTP Request.
This allows us to test the `undefined` image logo scenario for a service.

## List of changes proposed in this pull request
See changes list.

## How to test
Run the IO App through the dev server and navigate to national services. The  list should render correctly, while the service nr. 4 should not show a logo.
