### PR TITLE
chore(Firma con IO): Add signed message

### DIFF
--- a/src/payloads/features/fci/metadata.ts
+++ b/src/payloads/features/fci/metadata.ts
@@ -2,5 +2,5 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { Metadata } from "../../../../generated/definitions/fci/Metadata";
 
 export const mockFciMetadata: Metadata = {
-  serviceId: "mockedServiceId" as NonEmptyString
+  serviceId: "serviceFci" as NonEmptyString
 };

--- a/src/populate-persistence.ts
+++ b/src/populate-persistence.ts
@@ -38,6 +38,7 @@ import {
   frontMatterCTAFCISignatureRequest,
   frontMatterCTAFCISignatureRequestExpired,
   frontMatterCTAFCISignatureRequestRejected,
+  frontMatterCTAFCISignatureRequestSigned,
   frontMatterCTAFCISignatureRequestSignedExpired,
   frontMatterCTAFCISignatureRequestWaitQtsp,
   messageFciMarkdown,
@@ -301,7 +302,7 @@ const createMessages = (
         getNewMessage(
           customConfig,
           `Comune di Controguerra - Richiesta di Firma [SIGNED] - ${count} `,
-          frontMatterCTAFCISignatureRequest + messageFciSignedMarkdown
+          frontMatterCTAFCISignatureRequestSigned + messageFciSignedMarkdown
         )
       );
     });


### PR DESCRIPTION
## Short description
This PR adds a frontmatter for signature request with status SIGNED. Also adds related frontmatter.

## List of changes proposed in this pull request
- Update frontmatter
- Update populate-persistance

## How to test
With this config should to generate a message of a signature request with status SIGNED.
`{
  "profile": {
    "attrs": {
      "name": "Gian Maria"
    }
  },
  "messages":{
    "fci": {
      "signedCount": 1
    }
  }
}`