### PR TITLE
[IOPID-94] Add first lollipop consumer

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -3,5 +3,15 @@
     "attrs": {
       "name": "Gian Maria"
     }
+  },
+  "messages": {
+    "fci": 
+    { 
+      "waitForSignatureCount": 1, 
+      "rejectedCount": 1,
+      "expiredCount": 1, 
+      "waitForQtspCount": 1, 
+      "signedCount": 1 
+    } 
   }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -3,15 +3,5 @@
     "attrs": {
       "name": "Gian Maria"
     }
-  },
-  "messages": {
-    "fci": 
-    { 
-      "waitForSignatureCount": 1, 
-      "rejectedCount": 1,
-      "expiredCount": 1, 
-      "waitForQtspCount": 1, 
-      "signedCount": 1 
-    } 
   }
 }

--- a/src/persistence/lollipop.ts
+++ b/src/persistence/lollipop.ts
@@ -1,7 +1,10 @@
+import * as jose from "jose";
 import { AssertionRef } from "../../generated/definitions/backend/AssertionRef";
 import { DEFAULT_LOLLIPOP_HASH_ALGORITHM } from "../routers/public";
 
 let lollipopAssertionRef: AssertionRef | undefined = undefined;
+
+let lollipopPublicKey: jose.JWK | undefined = undefined;
 
 export function getAssertionRef() {
   return lollipopAssertionRef;
@@ -9,4 +12,12 @@ export function getAssertionRef() {
 
 export function setAssertionRef(key: string | undefined) {
   lollipopAssertionRef = `${DEFAULT_LOLLIPOP_HASH_ALGORITHM}-${key}` as AssertionRef;
+}
+
+export function getPublicKey() {
+  return lollipopPublicKey;
+}
+
+export function setPublicKey(key: jose.JWK | undefined) {
+  lollipopPublicKey = key;
 }

--- a/src/routers/features/lollipop/index.ts
+++ b/src/routers/features/lollipop/index.ts
@@ -1,0 +1,56 @@
+import { getProblemJson } from "../../../payloads/error";
+/**
+ * this router serves lollipop API
+ */
+import { Router } from "express";
+
+import { addHandler } from "../../../payloads/response";
+import { getAssertionRef, getPublicKey } from "../../../persistence/lollipop";
+import { verifySignatureHeader } from "@mattrglobal/http-signatures";
+import { signAlgorithmToVerifierMap } from "../../../utils/httpSignature";
+import { serverUrl } from "../../../utils/server";
+
+export const lollipopRouter = Router();
+
+export const DEFAULT_LOLLIPOP_HASH_ALGORITHM = "sha256";
+
+addHandler(lollipopRouter, "post", "/first-lollipop/sign", async (req, res) => {
+  const headers = req.headers;
+  const publicKey = getPublicKey();
+
+  if (!publicKey) {
+    return res.status(500).send(getProblemJson(500, "Public key not found"));
+  }
+
+  const requestOption = {
+    verifier: {
+      verify:
+        publicKey.kty === "EC"
+          ? signAlgorithmToVerifierMap["ecdsa-p256-sha256"].verify(publicKey)
+          : signAlgorithmToVerifierMap["rsa-pss-sha256"].verify(publicKey)
+    },
+    url: serverUrl,
+    method: req.method,
+    httpHeaders:
+      req.body["message"] === "INVALID"
+        ? { ...headers, "x-pagopa-lollipop-original-method": "xxx" }
+        : headers,
+    body: req.body,
+    verifyExpiry: false
+  };
+
+  try {
+    const verificationResult = await verifySignatureHeader(requestOption);
+    const verification = verificationResult.unwrapOr({
+      verified: false
+    }).verified;
+
+    if (verification) {
+      return res.send({ response: getAssertionRef() });
+    } else {
+      return res.status(400).send(getProblemJson(400, "Invalid signature"));
+    }
+  } catch (e) {
+    return res.status(500).send(getProblemJson(500, JSON.stringify(e)));
+  }
+});

--- a/src/routers/features/lollipop/index.ts
+++ b/src/routers/features/lollipop/index.ts
@@ -69,7 +69,7 @@ addHandler(lollipopRouter, "post", "/first-lollipop/sign", async (req, res) =>
             e => e as Error
           ),
           TE.foldW(
-            e => toTaskError(res, 500, JSON.stringify(e)),
+            e => toTaskError(res, 500, e.message, JSON.stringify(e.stack)),
             verificationResult =>
               pipe(
                 verificationResult.verified,

--- a/src/routers/features/lollipop/index.ts
+++ b/src/routers/features/lollipop/index.ts
@@ -8,7 +8,7 @@ import * as jose from "jose";
 /**
  * this router serves lollipop API
  */
-import { Request, Router } from "express";
+import { Request, Response, Router } from "express";
 
 import { addHandler } from "../../../payloads/response";
 import { getAssertionRef, getPublicKey } from "../../../persistence/lollipop";
@@ -20,12 +20,18 @@ export const lollipopRouter = Router();
 
 export const DEFAULT_LOLLIPOP_HASH_ALGORITHM = "sha256";
 
+const brokenVerifier = (_: jose.JWK) => {
+  throw new Error("broken verifier");
+};
+
 const toRequestOption = (req: Request, publicKey: jose.JWK) => {
   const headers = req.headers;
   return {
     verifier: {
       verify:
-        publicKey.kty === "EC"
+        req.body["message"] === "BROKEN"
+          ? brokenVerifier(publicKey)
+          : publicKey.kty === "EC"
           ? signAlgorithmToVerifierMap["ecdsa-p256-sha256"].verify(publicKey)
           : signAlgorithmToVerifierMap["rsa-pss-sha256"].verify(publicKey)
     },
@@ -40,13 +46,19 @@ const toRequestOption = (req: Request, publicKey: jose.JWK) => {
   };
 };
 
+const toTaskError = (
+  res: Response,
+  code: number,
+  title?: string,
+  detail?: string
+) => T.of(res.status(code).send(getProblemJson(code, title, detail)));
+
 addHandler(lollipopRouter, "post", "/first-lollipop/sign", async (req, res) =>
   pipe(
     getPublicKey(),
     O.fromNullable,
     O.foldW(
-      () =>
-        T.of(res.status(500).send(getProblemJson(500, "Public key not found"))),
+      () => toTaskError(res, 500, "Public key not found"),
       publicKey =>
         pipe(
           TE.tryCatch(
@@ -57,19 +69,17 @@ addHandler(lollipopRouter, "post", "/first-lollipop/sign", async (req, res) =>
             e => e as Error
           ),
           TE.foldW(
-            e =>
-              T.of(() =>
-                res.status(500).send(getProblemJson(500, JSON.stringify(e)))
-              ),
+            e => toTaskError(res, 500, JSON.stringify(e)),
             verificationResult =>
               pipe(
                 verificationResult.verified,
                 B.fold(
                   () =>
-                    T.of(
-                      res
-                        .status(400)
-                        .send(getProblemJson(400, "Invalid signature"))
+                    toTaskError(
+                      res,
+                      400,
+                      "Invalid signature",
+                      JSON.stringify(verificationResult)
                     ),
                   () => T.of(res.send({ response: getAssertionRef() }))
                 )

--- a/src/routers/public.ts
+++ b/src/routers/public.ts
@@ -1,11 +1,7 @@
 /**
  * this router serves all public API (those ones don't need session)
  */
-import {
-  SemverFromFromUserAgentString,
-  UserAgentSemver,
-  UserAgentSemverValid
-} from "@pagopa/ts-commons/lib/http-user-agent";
+import { UserAgentSemver } from "@pagopa/ts-commons/lib/http-user-agent";
 import { JwkPublicKey, parseJwkOrError } from "@pagopa/ts-commons/lib/jwk";
 import chalk from "chalk";
 import { Response, Router } from "express";
@@ -29,16 +25,19 @@ import { resetBonusVacanze } from "./features/bonus-vacanze";
 import { resetCgn } from "./features/cgn";
 import { resetProfile } from "./profile";
 import { resetWalletV2 } from "./walletsV2";
-import { setAssertionRef } from "../persistence/lollipop";
+import {
+  getPublicKey,
+  setAssertionRef,
+  setPublicKey
+} from "../persistence/lollipop";
+import { verifySignatureHeader } from "@mattrglobal/http-signatures";
+import { signAlgorithmToVerifierMap } from "../utils/httpSignature";
+import { serverUrl } from "../utils/server";
 
 export const publicRouter = Router();
 
 export const DEFAULT_LOLLIPOP_HASH_ALGORITHM = "sha256";
 const DEFAULT_HEADER_LOLLIPOP_PUB_KEY = "x-pagopa-lollipop-pub-key";
-const ACCEPTED_LOLLIPOP_USER_AGENT = {
-  clientName: "IO-App",
-  clientVersion: "2.23.0"
-} as UserAgentSemver;
 
 addHandler(publicRouter, "get", "/login", async (req, res) => {
   const lollipopPublicKeyHeaderValue = req.get(DEFAULT_HEADER_LOLLIPOP_PUB_KEY);
@@ -64,12 +63,57 @@ addHandler(publicRouter, "get", "/login", async (req, res) => {
   );
 
   setAssertionRef(thumbprint);
+  setPublicKey(jwkPK.right);
 
   const samlRequest = getSamlRequest(
     DEFAULT_LOLLIPOP_HASH_ALGORITHM,
     thumbprint
   );
   handleLollipopLoginRedirect(res, samlRequest, thumbprint);
+});
+
+const toResponseMessage = (message: string) => {
+  return { message };
+};
+addHandler(publicRouter, "post", "/first-lollipop/sign", async (req, res) => {
+  const headers = req.headers;
+  const publicKey = getPublicKey();
+
+  if (!publicKey) {
+    return res.status(500).send(toResponseMessage("Public key not found"));
+  }
+
+  const requestOption = {
+    verifier: {
+      verify:
+        publicKey.kty === "EC"
+          ? signAlgorithmToVerifierMap["ecdsa-p256-sha256"].verify(publicKey)
+          : signAlgorithmToVerifierMap["rsa-pss-sha256"].verify(publicKey)
+    },
+    url: serverUrl,
+    method: req.method,
+    httpHeaders:
+      req.body["message"] === "INVALID"
+        ? { ...headers, "x-pagopa-lollipop-original-method": "xxx" }
+        : headers,
+    body: req.body,
+    verifyExpiry: false
+  };
+
+  try {
+    const verificationResult = await verifySignatureHeader(requestOption);
+    const verification = verificationResult.unwrapOr({
+      verified: false
+    }).verified;
+
+    if (verification) {
+      return res.send({ body: req.body, result: "verified" });
+    } else {
+      return res.status(403).send(toResponseMessage("Invalid signature"));
+    }
+  } catch (e) {
+    return res.status(500).send(toResponseMessage(JSON.stringify(e)));
+  }
 });
 
 addHandler(publicRouter, "get", "/idp-login", (req, res) => {

--- a/src/routers/public.ts
+++ b/src/routers/public.ts
@@ -26,6 +26,7 @@ import { resetCgn } from "./features/cgn";
 import { resetProfile } from "./profile";
 import { resetWalletV2 } from "./walletsV2";
 import {
+  getAssertionRef,
   getPublicKey,
   setAssertionRef,
   setPublicKey
@@ -108,7 +109,7 @@ addHandler(publicRouter, "post", "/first-lollipop/sign", async (req, res) => {
     }).verified;
 
     if (verification) {
-      return res.send({ body: req.body, result: "verified" });
+      return res.send({ response: getAssertionRef() });
     } else {
       return res.status(403).send(toResponseMessage("Invalid signature"));
     }

--- a/src/routers/public.ts
+++ b/src/routers/public.ts
@@ -72,12 +72,13 @@ addHandler(publicRouter, "get", "/login", async (req, res) => {
   handleLollipopLoginRedirect(res, samlRequest, thumbprint);
 });
 
-const toResponseMessage = (message: string) => {
-  return { message };
-};
 addHandler(publicRouter, "post", "/first-lollipop/sign", async (req, res) => {
   const headers = req.headers;
   const publicKey = getPublicKey();
+
+  const toResponseMessage = (message: string) => {
+    return { message };
+  };
 
   if (!publicKey) {
     return res.status(500).send(toResponseMessage("Public key not found"));

--- a/src/routers/public.ts
+++ b/src/routers/public.ts
@@ -1,3 +1,4 @@
+import { getProblemJson } from "./../payloads/error";
 /**
  * this router serves all public API (those ones don't need session)
  */
@@ -77,12 +78,8 @@ addHandler(publicRouter, "post", "/first-lollipop/sign", async (req, res) => {
   const headers = req.headers;
   const publicKey = getPublicKey();
 
-  const toResponseMessage = (message: string) => {
-    return { message };
-  };
-
   if (!publicKey) {
-    return res.status(500).send(toResponseMessage("Public key not found"));
+    return res.status(500).send(getProblemJson(500, "Public key not found"));
   }
 
   const requestOption = {
@@ -111,10 +108,10 @@ addHandler(publicRouter, "post", "/first-lollipop/sign", async (req, res) => {
     if (verification) {
       return res.send({ response: getAssertionRef() });
     } else {
-      return res.status(403).send(toResponseMessage("Invalid signature"));
+      return res.status(400).send(getProblemJson(400, "Invalid signature"));
     }
   } catch (e) {
-    return res.status(500).send(toResponseMessage(JSON.stringify(e)));
+    return res.status(500).send(getProblemJson(500, JSON.stringify(e)));
   }
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,7 @@ import { satispayRouter } from "./routers/walletsV2/methods/satispay";
 import { payPalRouter } from "./routers/walletsV3/methods/paypal";
 import { delayer } from "./utils/delay_middleware";
 import { idpayRouter } from "./routers/features/idpay";
+import { lollipopRouter } from "./routers/features/lollipop";
 // create express server
 const app: Application = express();
 // parse body request as json
@@ -85,7 +86,8 @@ app.use(errorMiddleware);
   cdcRouter,
   fciRouter,
   pnRouter,
-  idpayRouter
+  idpayRouter,
+  lollipopRouter
 ].forEach(r => app.use(r));
 
 export default app;


### PR DESCRIPTION
## Short description
This PR adds the lollipop endpoint `/first-lollipop/sign` to `publicRouter`.

## List of changes proposed in this pull request
- [src/persistence/lollipop.ts](https://github.com/pagopa/io-dev-api-server/pull/233/files#diff-05cf9f859fe60f756b7fb4ae8f448cab04c77f4706ef05fee53db351fa8a04a5): Adds public key persistence.
- [src/routers/features/lollipop/index.ts](https://github.com/pagopa/io-dev-api-server/pull/233/files#diff-63cd54ee658a7a4b7642857b2a08d3a746aad58d3efe73dfc0507ee29ff83511): Adds specific router.
- [src/routers/public.ts](https://github.com/pagopa/io-dev-api-server/pull/233/files#diff-a8ab3f294071f8e4ff9cdb51c80a7b0410b4c7a0a1b28581b7275339ff65add8): Persists the public key during the login phase.
- [src/server.ts](https://github.com/pagopa/io-dev-api-server/pull/233/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595): Add the new router to the server.

## How to test
Test the new API endpoint with this [PR](https://github.com/pagopa/io-app/pull/4545) if not already merged.
