### PR TITLE
Added authentication redirect with iologin urlScheme

### DIFF
--- a/src/payloads/login.ts
+++ b/src/payloads/login.ts
@@ -3,3 +3,4 @@ export const loginLolliPopRedirect: string = "/idp-login";
 const redirectUrl: string = "/profile.html?token=";
 export const errorRedirectUrl: string = "/error.html?errorCode=";
 export const loginWithToken = `${redirectUrl}${loginSessionToken}`;
+export const appUrlLoginScheme = "iologin";

--- a/src/routers/public.ts
+++ b/src/routers/public.ts
@@ -12,6 +12,7 @@ import * as zlib from "zlib";
 import { assetsFolder, ioDevServerConfig } from "../config";
 import { backendInfo } from "../payloads/backend";
 import {
+  appUrlLoginScheme,
   errorRedirectUrl,
   loginLolliPopRedirect,
   loginSessionToken,
@@ -67,11 +68,13 @@ addHandler(publicRouter, "get", "/login", async (req, res) => {
 
 addHandler(publicRouter, "get", "/idp-login", (req, res) => {
   if (req.query.authorized === "1" || ioDevServerConfig.global.autoLogin) {
-    res.redirect(loginWithToken);
+    const url = `${appUrlLoginScheme}://${req.headers.host}${loginWithToken}`
+    res.redirect(url);
     return;
   }
   if (req.query.error) {
-    res.redirect(`${errorRedirectUrl}${req.query.error}`);
+    const url = `${appUrlLoginScheme}://${req.headers.host}${errorRedirectUrl}${req.query.error}`
+    res.redirect(url);
     return;
   }
   sendFile("assets/html/login.html", res);


### PR DESCRIPTION
## Short description
This PR edits the redirect urlScheme at the end of login phase, to allow the authentication with native component.

## List of changes proposed in this pull request
- src/payloads/login.ts: added the new scheme;
- src/routers/public.ts: read `Short description`

## How to test
Try to login with devServer and check if the final redirect starts with `iologin://`
