### PR TITLE
chore(Firma con IO): [SFEQS-1651] Add signature request with no fields

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -89,7 +89,8 @@ const defaultConfig: IoDevServerConfig = {
       expiredCount: 0,
       expired90Count: 0,
       waitForQtspCount: 0,
-      signedCount: 0
+      signedCount: 0,
+      noSignatureFieldsCount: 0
     },
     withCTA: false,
     withEUCovidCert: false,

--- a/src/payloads/features/fci/signature-request.ts
+++ b/src/payloads/features/fci/signature-request.ts
@@ -18,6 +18,7 @@ export const WAIT_QTSP_SIGNATURE_REQUEST_ID = ulid() as NonEmptyString;
 export const SIGNED_SIGNATURE_REQUEST_ID = ulid() as NonEmptyString;
 export const SIGNED_EXPIRED_SIGNATURE_REQUEST_ID = ulid() as NonEmptyString;
 export const REJECTED_SIGNATURE_REQUEST_ID = ulid() as NonEmptyString;
+export const NO_FIELDS_SIGNATURE_REQUEST_ID = ulid() as NonEmptyString;
 export const DOSSIER_ID = ulid() as NonEmptyString;
 export const SIGNATURE_ID = ulid() as NonEmptyString;
 

--- a/src/populate-persistence.ts
+++ b/src/populate-persistence.ts
@@ -37,6 +37,7 @@ import {
   frontMatterBonusVacanze,
   frontMatterCTAFCISignatureRequest,
   frontMatterCTAFCISignatureRequestExpired,
+  frontMatterCTAFCISignatureRequestNoFields,
   frontMatterCTAFCISignatureRequestRejected,
   frontMatterCTAFCISignatureRequestSigned,
   frontMatterCTAFCISignatureRequestSignedExpired,
@@ -306,6 +307,19 @@ const createMessages = (
         )
       );
     });
+
+  customConfig.messages.fci.noSignatureFieldsCount > 0 &&
+    range(1, customConfig.messages.fci.noSignatureFieldsCount).forEach(
+      count => {
+        output.push(
+          getNewMessage(
+            customConfig,
+            `Comune di Controguerra - Richiesta di Firma [WITH NO SIGNATURE FIELDS] - ${count} `,
+            frontMatterCTAFCISignatureRequestNoFields + messageFciMarkdown
+          )
+        );
+      }
+    );
 
   /* standard message */
   customConfig.messages.standardMessageCount > 0 &&

--- a/src/routers/features/fci/index.ts
+++ b/src/routers/features/fci/index.ts
@@ -8,6 +8,7 @@ import { qtspFilledDocument } from "../../../payloads/features/fci/qtsp-filled-d
 import { mockSignatureDetailView } from "../../../payloads/features/fci/signature-detail-request";
 import {
   EXPIRED_SIGNATURE_REQUEST_ID,
+  NO_FIELDS_SIGNATURE_REQUEST_ID,
   REJECTED_SIGNATURE_REQUEST_ID,
   SIGNATURE_REQUEST_ID,
   signatureRequestDetailViewDoc,
@@ -41,7 +42,8 @@ addHandler(
         signatureReqId === WAIT_QTSP_SIGNATURE_REQUEST_ID ||
         signatureReqId === SIGNED_SIGNATURE_REQUEST_ID ||
         signatureReqId === SIGNED_EXPIRED_SIGNATURE_REQUEST_ID ||
-        signatureReqId === REJECTED_SIGNATURE_REQUEST_ID
+        signatureReqId === REJECTED_SIGNATURE_REQUEST_ID ||
+        signatureReqId === NO_FIELDS_SIGNATURE_REQUEST_ID
           ? O.some(signatureReqId)
           : O.none
       ),
@@ -78,6 +80,15 @@ addHandler(
                   id: REJECTED_SIGNATURE_REQUEST_ID,
                   updated_at: new Date(now.setDate(now.getDate() - 91)),
                   status: SignatureRequestStatusEnum.REJECTED
+                }
+              : signatureReqId === NO_FIELDS_SIGNATURE_REQUEST_ID
+              ? {
+                  ...signatureRequestDetailViewDoc,
+                  status: SignatureRequestStatusEnum.WAIT_FOR_SIGNATURE,
+                  documents: signatureRequestDetailViewDoc.documents.map(d => ({
+                    ...d,
+                    metadata: { ...d.metadata, signature_fields: [] }
+                  }))
                 }
               : {
                   ...signatureRequestDetailViewDoc,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -167,7 +167,8 @@ export const IoDevServerConfig = t.interface({
         expiredCount: t.number,
         expired90Count: t.number,
         waitForQtspCount: t.number,
-        signedCount: t.number
+        signedCount: t.number,
+        noSignatureFieldsCount: t.number
       }),
       // if true, messages (all available) with nested CTA will be included
       withCTA: t.boolean,

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -1,5 +1,6 @@
 import {
   EXPIRED_SIGNATURE_REQUEST_ID,
+  NO_FIELDS_SIGNATURE_REQUEST_ID,
   REJECTED_SIGNATURE_REQUEST_ID,
   SIGNATURE_REQUEST_ID,
   SIGNED_EXPIRED_SIGNATURE_REQUEST_ID,
@@ -261,6 +262,17 @@ en:
     cta_1: 
         text: "View documents"
         action: "ioit://fci/main?signatureRequestId=${SIGNED_EXPIRED_SIGNATURE_REQUEST_ID}"
+---`;
+
+export const frontMatterCTAFCISignatureRequestNoFields = `---
+it:
+    cta_1: 
+        text: "Visualizza i documenti"
+        action: "ioit://fci/main?signatureRequestId=${NO_FIELDS_SIGNATURE_REQUEST_ID}"
+en:
+    cta_1: 
+        text: "View documents"
+        action: "ioit://fci/main?signatureRequestId=${NO_FIELDS_SIGNATURE_REQUEST_ID}"
 ---`;
 
 export const messageFciMarkdown = `


### PR DESCRIPTION
## Short description
This PR adds signature request with no fields.

## List of changes proposed in this pull request
- Update payloads
- Update config
- Update getSignatureRequestById

## How to test
Tests should solve correctly. Using a config to generate a signature request with no fields a message should appear in io-app. The signing flow shouldn't have signature fields.