### PR TITLE
chore: Fix no error on empty "signature-input" header

### DIFF
--- a/src/routers/features/lollipop/index.ts
+++ b/src/routers/features/lollipop/index.ts
@@ -55,17 +55,15 @@ const toTaskError = (
 
 addHandler(lollipopRouter, "post", "/first-lollipop/sign", async (req, res) =>
   pipe(
-    req.headers.signature,
-    O.fromNullable,
-    O.foldW(
-      () => toTaskError(res, 500, "signature header not found"),
-      _ =>
+    req.headers.signature !== "",
+    B.foldW(
+      () => toTaskError(res, 500, "signature header is empty"),
+      () =>
         pipe(
-          req.headers["signature-input"],
-          O.fromNullable,
-          O.foldW(
-            () => toTaskError(res, 500, "signature-input header not found"),
-            _ =>
+          req.headers["signature-input"] !== "",
+          B.foldW(
+            () => toTaskError(res, 500, "signature-input header is empty"),
+            () =>
               pipe(
                 getPublicKey(),
                 O.fromNullable,


### PR DESCRIPTION
## Short description
This PR return an error when the `signature-input` header is empty.

## List of changes proposed in this pull request
See commit list

## How to test
Try the lollipop playground with IO-APP by providing an empty string for `signature-input` header.

Using Proxyman you can do that by scripting over this url: http: //localhost:3000/first-lollipop/sign

```js
async function onRequest(context, url, request) {
  // console.log(request);
  console.log(url);

  // Update or Add new headers
  //delete request.headers.signature;
  //delete request.headers["signature-input"];
  request.headers["signature-input"] = ""
  //request.headers["signature"] = ""
  //request.headers["content-digest"] = "foo"


  // Done
  return request;
}
```
