### PR TITLE
[IOCOM-253,IOCOM-258] Lollipop middleware and third party message endpoints with lollipop

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -96,3 +96,30 @@ $ cp .env.local .env
 # Run the app on iOS or Android
 $ yarn run-ios (or yarn-run-android)
 ```
+
+## Lollipop
+Server is able to verify lollipop header's signatures on incoming requests, provided a previously valid login that set both public key and public assertion (`GET /login` endpoint).
+
+In order to enable lollipop on an endpoint, just wrap the middleware function that handles such endpoint with the `lollipopMiddleware` function (`src/middleware/lollipopMiddleware.ts`).
+```
+// Handler without lollipop
+addHandler(
+  messageRouter,
+  "get",
+  addApiV1Prefix("/third-party-messages/:id/precondition"),
+  (req, res) => {...}
+)
+
+// Handler with lollipop
+addHandler(
+  messageRouter,
+  "get",
+  addApiV1Prefix("/third-party-messages/:id/precondition"),
+  lollipopMiddleware((req, res) => {...})
+)
+```
+
+The lollipop middleware runs before the wrapped function and automatically rejects-and-block any request that is not lollipop compliant (so the wrapped function is not executed in such case).
+Public key and Assertion Ref can be retrieved using `getPublicKey` and `getAssertionRef` (`src/persistence/lollipop.ts` - provided a previously valid login on the GET /login endpoint).
+
+Regardless of how many endpoints have been wrapped, the lollipop middleware can be globally disabled using the `config.feature.lollipop.enabled` flag (default true).

--- a/src/config.ts
+++ b/src/config.ts
@@ -156,6 +156,9 @@ const defaultConfig: IoDevServerConfig = {
     idpay: {
       ibanSize: 3
     },
+    lollipop: {
+      enabled: true
+    },
     allowRandomValues: true
   }
 };

--- a/src/middleware/lollipopMiddleware.ts
+++ b/src/middleware/lollipopMiddleware.ts
@@ -26,7 +26,6 @@ export const isLollipopConfigEnabled = () =>
 export const lollipopMiddleware =
   (nextMiddleware: (embeddedRequest: Request, _: Response) => void) =>
   async (request: Request, response: Response) => {
-    console.log(`MIDDLEWARE`);
     pipe(
       isLollipopConfigEnabled(),
       B.fold(

--- a/src/middleware/lollipopMiddleware.ts
+++ b/src/middleware/lollipopMiddleware.ts
@@ -51,8 +51,8 @@ export const lollipopMiddleware =
     );
   };
 
-const verifyLollipopSignatureHeader = async (req: Request, _: Response) =>
-  await pipe(
+const verifyLollipopSignatureHeader = (req: Request, _: Response) =>
+  pipe(
     req.headers["signature-input"],
     NonEmptyString.decode,
     E.foldW(

--- a/src/middleware/lollipopMiddleware.ts
+++ b/src/middleware/lollipopMiddleware.ts
@@ -1,0 +1,122 @@
+import { pipe } from "fp-ts/lib/function";
+import * as O from "fp-ts/lib/Option";
+import * as TE from "fp-ts/lib/TaskEither";
+import * as T from "fp-ts/lib/Task";
+import * as B from "fp-ts/lib/boolean";
+import * as E from "fp-ts/lib/Either";
+import * as jose from "jose";
+import { Request, Response } from "express-serve-static-core";
+import { verifySignatureHeader } from "@mattrglobal/http-signatures";
+import { getPublicKey } from "../persistence/lollipop";
+import { ioDevServerConfig } from "../config";
+import { signAlgorithmToVerifierMap } from "../utils/httpSignature";
+import { serverUrl } from "../utils/server";
+import { getProblemJson } from "../payloads/error";
+
+type LollipopHTTPStatusError = {
+  code: number;
+  problemJson: string;
+};
+
+export const DEFAULT_LOLLIPOP_HASH_ALGORITHM = "sha256";
+
+export const isLollipopConfigEnabled = () =>
+  ioDevServerConfig.features.lollipop.enabled;
+
+export const lollipopMiddleware =
+  (nextMiddleware: (embeddedRequest: Request, _: Response) => void) =>
+  async (request: Request, response: Response) => {
+    console.log(`MIDDLEWARE`);
+    pipe(
+      isLollipopConfigEnabled(),
+      B.fold(
+        () => nextMiddleware(request, response),
+        async () =>
+          pipe(
+            await verifyLollipopSignatureHeader(request, response),
+            E.foldW(
+              error => response.status(error.code).send(error.problemJson),
+              _ => nextMiddleware(request, response)
+            )
+          )
+      )
+    );
+  };
+
+const verifyLollipopSignatureHeader = async (req: Request, _: Response) =>
+  await pipe(
+    getPublicKey(),
+    O.fromNullable,
+    O.foldW(
+      () => T.of(toFailureEither(500, "Public key not found")),
+      publicKey =>
+        pipe(
+          TE.tryCatch(
+            () =>
+              verifySignatureHeader(
+                toVerifySignatureHeaderOptions(req, publicKey)
+              ).unwrapOr({
+                verified: false
+              }),
+            e => e as Error
+          ),
+          TE.foldW(
+            e => T.of(toFailureEither(500, e.message, JSON.stringify(e.stack))),
+            verificationResult =>
+              pipe(
+                verificationResult.verified,
+                B.fold(
+                  () =>
+                    T.of(
+                      toFailureEither(
+                        400,
+                        "Invalid signature",
+                        JSON.stringify(verificationResult)
+                      )
+                    ),
+                  () => T.of(toSuccessEither())
+                )
+              )
+          )
+        )
+    )
+  )();
+
+const toVerifySignatureHeaderOptions = (req: Request, publicKey: jose.JWK) => {
+  const headers = req.headers;
+  return {
+    verifier: {
+      verify:
+        req.body.message === "BROKEN"
+          ? brokenVerifier(publicKey)
+          : publicKey.kty === "EC"
+          ? signAlgorithmToVerifierMap["ecdsa-p256-sha256"].verify(publicKey)
+          : signAlgorithmToVerifierMap["rsa-pss-sha256"].verify(publicKey)
+    },
+    url: serverUrl,
+    method: req.method,
+    httpHeaders:
+      req.body.message === "INVALID"
+        ? { ...headers, "x-pagopa-lollipop-original-method": "xxx" }
+        : headers,
+    body: req.body,
+    verifyExpiry: false
+  };
+};
+
+const brokenVerifier = (_: jose.JWK) => {
+  throw new Error("broken verifier");
+};
+
+const toSuccessEither = (): E.Either<LollipopHTTPStatusError, true> =>
+  E.right(true);
+
+const toFailureEither = (
+  code: number,
+  title?: string,
+  detail?: string
+): E.Either<LollipopHTTPStatusError, true> =>
+  E.left({
+    code,
+    problemJson: getProblemJson(code, title, detail)
+  } as LollipopHTTPStatusError);

--- a/src/routers/__tests__/message.test.ts
+++ b/src/routers/__tests__/message.test.ts
@@ -12,6 +12,7 @@ import ServicesDB from "../../persistence/services";
 import populatePersistence from "../../populate-persistence";
 import app from "../../server";
 import { pnServiceId } from "../../payloads/services/special/pn/factoryPn";
+import * as lollipopMid from "../../middleware/lollipopMiddleware";
 
 const request = supertest(app);
 
@@ -314,12 +315,15 @@ describe("given the `/messages/:id` endpoint", () => {
 
 describe("given the `/third-party-messages/:id/precondition` endpoint", () => {
   beforeAll(() => {
+    jest.spyOn(lollipopMid, "isLollipopConfigEnabled").mockReturnValue(false);
     populatePersistence(customConfig);
   });
 
   afterAll(() => {
     MessagesDB.dropAll();
     ServicesDB.deleteServices();
+    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it("should return 200 with the remoted precondition", async () => {

--- a/src/routers/features/lollipop/index.ts
+++ b/src/routers/features/lollipop/index.ts
@@ -1,91 +1,19 @@
-import { pipe } from "fp-ts/lib/function";
-import * as O from "fp-ts/lib/Option";
-import * as TE from "fp-ts/lib/TaskEither";
-import * as T from "fp-ts/lib/Task";
-import * as B from "fp-ts/lib/boolean";
-import * as jose from "jose";
-import { Request, Response, Router } from "express";
-import { verifySignatureHeader } from "@mattrglobal/http-signatures";
-import { getProblemJson } from "../../../payloads/error";
 /**
  * this router serves lollipop API
  */
 
+import { Router } from "express";
 import { addHandler } from "../../../payloads/response";
-import { getAssertionRef, getPublicKey } from "../../../persistence/lollipop";
-import { signAlgorithmToVerifierMap } from "../../../utils/httpSignature";
-import { serverUrl } from "../../../utils/server";
+import { getAssertionRef } from "../../../persistence/lollipop";
+import { lollipopMiddleware } from "../../../middleware/lollipopMiddleware";
 
 export const lollipopRouter = Router();
 
-export const DEFAULT_LOLLIPOP_HASH_ALGORITHM = "sha256";
-
-const brokenVerifier = (_: jose.JWK) => {
-  throw new Error("broken verifier");
-};
-
-const toRequestOption = (req: Request, publicKey: jose.JWK) => {
-  const headers = req.headers;
-  return {
-    verifier: {
-      verify:
-        req.body.message === "BROKEN"
-          ? brokenVerifier(publicKey)
-          : publicKey.kty === "EC"
-          ? signAlgorithmToVerifierMap["ecdsa-p256-sha256"].verify(publicKey)
-          : signAlgorithmToVerifierMap["rsa-pss-sha256"].verify(publicKey)
-    },
-    url: serverUrl,
-    method: req.method,
-    httpHeaders:
-      req.body.message === "INVALID"
-        ? { ...headers, "x-pagopa-lollipop-original-method": "xxx" }
-        : headers,
-    body: req.body,
-    verifyExpiry: false
-  };
-};
-
-const toTaskError = (
-  res: Response,
-  code: number,
-  title?: string,
-  detail?: string
-) => T.of(res.status(code).send(getProblemJson(code, title, detail)));
-
-addHandler(lollipopRouter, "post", "/first-lollipop/sign", async (req, res) =>
-  pipe(
-    getPublicKey(),
-    O.fromNullable,
-    O.foldW(
-      () => toTaskError(res, 500, "Public key not found"),
-      publicKey =>
-        pipe(
-          TE.tryCatch(
-            () =>
-              verifySignatureHeader(toRequestOption(req, publicKey)).unwrapOr({
-                verified: false
-              }),
-            e => e as Error
-          ),
-          TE.foldW(
-            e => toTaskError(res, 500, e.message, JSON.stringify(e.stack)),
-            verificationResult =>
-              pipe(
-                verificationResult.verified,
-                B.fold(
-                  () =>
-                    toTaskError(
-                      res,
-                      400,
-                      "Invalid signature",
-                      JSON.stringify(verificationResult)
-                    ),
-                  () => T.of(res.send({ response: getAssertionRef() }))
-                )
-              )
-          )
-        )
-    )
-  )()
+addHandler(
+  lollipopRouter,
+  "post",
+  "/first-lollipop/sign",
+  lollipopMiddleware((req, res) => {
+    res.send({ response: getAssertionRef() });
+  })
 );

--- a/src/routers/message.ts
+++ b/src/routers/message.ts
@@ -1,4 +1,4 @@
-import { Request, Response, Router } from "express";
+import { Router } from "express";
 import * as E from "fp-ts/lib/Either";
 import { identity, pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -268,6 +268,9 @@ export const IoDevServerConfig = t.interface({
       idpay: t.interface({
         // The size of the IBAN list to generate
         ibanSize: t.number
+      }),
+      lollipop: t.interface({
+        enabled: t.boolean
       })
     }),
     AllowRandomValue


### PR DESCRIPTION
## Short description
This PR refactors lollipop checks and adds the new lollipop middleware.

## List of changes proposed in this pull request
- Lollipop logic in `src/routers/features/lollipop/index.ts` has been moved to `src/middleware/lollipopMiddleware.ts`
- The following endpoints use the lollipop middleware:
  - message precondition
  - third party message
  - third party message attachments
  - lollipop playground
- global configuration to disable every lollipop middleware in `/src/config.ts`
- README.md updated with instructions on how to use lollipop

## How to test
- With the global lollipop configuration enabled, check that the previous endpoints do not work with improper headers.
- Repeat the same test but with global lollipop configuration disabled (endpoints shall work)
- Using the latest master deploy of io-app (with lollipop enabled globally), check that, for any PN message:
  - preconditions are retrieved
  - third party message is retrieved
  - attachments are retrieved
