### PR TITLE
[SIW-240] Set lollipop min app version to 0.0.0

### DIFF
--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -77,8 +77,8 @@ export const backendStatus: BackendStatus = {
     lollipop: {
       enabled: false,
       min_app_version: {
-        ios: "1.2.3",
-        android: "1.2.3"
+        ios: "0.0.0",
+        android: "0.0.0"
       }
     },
     pn: {


### PR DESCRIPTION
## Short description
This PR changes the lollipop min app version to 0.0.0 in order for the it-wallet POC to work with the dev server. 
The POC starts from version 0.0.0. 

## List of changes proposed in this pull request
- `src/payloads/backend.ts`: Changes the lollipop min app version to 0.0.0.

## How to test
Run the io-dev-api-server and the app pointing at the `bundle/it-wallet` branch.
Comment the following code in `ts/screens/modal/RootModal.tsx`: 
`if (!props.isAppSupported) {
    void mixpanelTrack("UPDATE_APP_MODAL", {
      minVersioniOS: props.versionInfo?.min_app_version.ios,
      minVersionAndroid: props.versionInfo?.min_app_version.android
    });
    return <UpdateAppModal />;
  }`
Login should be successful.
