### PR TITLE
chore: [PE-453,PE-454] Add support type, value and allNationalAddresses flag to merchant

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "api_public_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v12.6.1-RELEASE/api_public.yaml",
   "api_bonus_vacanze": "https://raw.githubusercontent.com/pagopa/io-backend/v12.6.1-RELEASE/api_bonus.yaml",
   "api_cgn": "https://raw.githubusercontent.com/pagopa/io-backend/v12.6.1-RELEASE/api_cgn.yaml",
-  "api_cgn_merchants": "https://raw.githubusercontent.com/pagopa/io-backend/v12.6.1-RELEASE/api_cgn_operator_search.yaml",
+  "api_cgn_merchants": "https://raw.githubusercontent.com/pagopa/io-backend/pe-439-444/api_cgn_operator_search.yaml",
   "api_cgn_geo": "https://raw.githubusercontent.com/pagopa/io-backend/here_geoapi_integration/api_geo.yaml",
   "content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.26/definitions.yml",
   "api_pagopa_walletv2": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.26/bonus/specs/bpd/pm/walletv2.json",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "api_public_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v12.6.1-RELEASE/api_public.yaml",
   "api_bonus_vacanze": "https://raw.githubusercontent.com/pagopa/io-backend/v12.6.1-RELEASE/api_bonus.yaml",
   "api_cgn": "https://raw.githubusercontent.com/pagopa/io-backend/v12.6.1-RELEASE/api_cgn.yaml",
-  "api_cgn_merchants": "https://raw.githubusercontent.com/pagopa/io-backend/pe-439-444/api_cgn_operator_search.yaml",
+  "api_cgn_merchants": "https://raw.githubusercontent.com/pagopa/io-backend/v13.2.1-RELEASE/api_cgn_operator_search.yaml",
   "api_cgn_geo": "https://raw.githubusercontent.com/pagopa/io-backend/here_geoapi_integration/api_geo.yaml",
   "content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.26/definitions.yml",
   "api_pagopa_walletv2": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.26/bonus/specs/bpd/pm/walletv2.json",

--- a/src/payloads/features/cgn/merchants.ts
+++ b/src/payloads/features/cgn/merchants.ts
@@ -19,6 +19,9 @@ import {
 } from "../../../../generated/definitions/cgn/merchants/ProductCategory";
 import { getRandomValue } from "../../../utils/random";
 import { serverUrl } from "../../../utils/server";
+import { SupportTypeEnum } from "../../../../generated/definitions/cgn/merchants/SupportType";
+import { getRandomEnumValue } from "../../utils/random";
+import { ALL_NATIONAL_ADDRESSES_TEXT, getSupportValueFromType } from "./utils";
 
 const availableCategories: ReadonlyArray<ProductCategory> = [
   ProductCategoryEnum.cultureAndEntertainment,
@@ -181,6 +184,7 @@ const generateDiscount = (
 export const generateMerchantDetail = (
   merchant: OnlineMerchant | OfflineMerchant
 ): Merchant => {
+  const supportType = getRandomEnumValue(SupportTypeEnum);
   if (OnlineMerchant.is(merchant)) {
     return {
       id: merchant.id,
@@ -194,17 +198,21 @@ export const generateMerchantDetail = (
         faker.datatype.number({ min: 1, max: 4 })
       ).map<Discount>(_ =>
         generateDiscount(merchant.productCategories, merchant.discountCodeType)
-      )
+      ),
+      allNationalAddresses: true,
+      supportType,
+      supportValue: getSupportValueFromType(supportType)
     };
   } else {
+    const addresses = range(0, faker.datatype.number({ min: 0, max: 3 }));
     return {
       id: merchant.id,
       name: merchant.name,
-      addresses: range(
-        0,
-        faker.datatype.number({ min: 1, max: 4 })
-      ).map<Address>(_ => ({
-        full_address: faker.address.streetAddress(true) as NonEmptyString
+      addresses: addresses.map<Address>(_ => ({
+        full_address:
+          addresses.length === 1
+            ? (ALL_NATIONAL_ADDRESSES_TEXT as NonEmptyString)
+            : (faker.address.streetAddress(true) as NonEmptyString)
       })),
       imageUrl: faker.image.imageUrl() as NonEmptyString,
       description: faker.lorem.paragraphs(2) as NonEmptyString,
@@ -212,7 +220,10 @@ export const generateMerchantDetail = (
         0,
         faker.datatype.number({ min: 1, max: 4 })
       ).map<Discount>(_ => generateDiscount(merchant.productCategories)),
-      websiteUrl: faker.internet.url() as NonEmptyString
+      websiteUrl: faker.internet.url() as NonEmptyString,
+      allNationalAddresses: addresses.length === 1,
+      supportType,
+      supportValue: getSupportValueFromType(supportType)
     };
   }
 };

--- a/src/payloads/features/cgn/utils.ts
+++ b/src/payloads/features/cgn/utils.ts
@@ -1,0 +1,17 @@
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { faker } from "@faker-js/faker/locale/it";
+import { SupportTypeEnum } from "../../../../generated/definitions/cgn/merchants/SupportType";
+
+export const ALL_NATIONAL_ADDRESSES_TEXT =
+  "Tutti i punti vendita sul territorio nazionale";
+
+export const getSupportValueFromType = (supportType: SupportTypeEnum) => {
+  switch (supportType) {
+    case SupportTypeEnum.EMAILADDRESS:
+      return faker.internet.email() as NonEmptyString;
+    case SupportTypeEnum.PHONENUMBER:
+      return faker.phone.number("+39 #########") as NonEmptyString;
+    case SupportTypeEnum.WEBSITE:
+      return faker.internet.url() as NonEmptyString;
+  }
+};


### PR DESCRIPTION
## Short description
This PR adds new mock for new mandatory attributes of `Merchant`: `supportType`, `supportValue` and `allNationalAddresses` in order to show a new "Contact section" into merchant details screen.

## List of changes proposed in this pull request
- Added an `util.ts` file under `cgn` folder with all the utilities used for that feature;
- Mapped all three mandatory attributes for the mocked response;

## How to test
Use postman in order to check if the response of _GET /merchants/:merchantId_ gives as output `supportType`, `supportValue` and `allNationalAddresses`
