### PR TITLE
Fix: IDPay initiatives status by wallet id

### DIFF
--- a/src/payloads/features/idpay/get-initiatives-with-instrument.ts
+++ b/src/payloads/features/idpay/get-initiatives-with-instrument.ts
@@ -9,6 +9,7 @@ import { WalletV2 } from "../../../../generated/definitions/pagopa/WalletV2";
 import { CardInfo } from "../../../../generated/definitions/pagopa/walletv2/CardInfo";
 import { initiatives, instruments } from "../../../persistence/idpay";
 import { getWalletV2 } from "../../../routers/walletsV2";
+import { EnableableFunctionsEnum } from "../../../../generated/definitions/pagopa/EnableableFunctions";
 
 const initiativesStatusByWalletId = (
   idWallet: string
@@ -31,7 +32,13 @@ const initiativesStatusByWalletId = (
   }, [] as ReadonlyArray<InitiativesStatusDTO>);
 
 const getWalletById = (id: number): O.Option<WalletV2> =>
-  O.fromNullable(getWalletV2().find(w => w.idWallet === id));
+  O.fromNullable(
+    getWalletV2().find(
+      w =>
+        w.idWallet === id &&
+        w.enableableFunctions?.includes(EnableableFunctionsEnum.BPD)
+    )
+  );
 
 export const getInitiativeWithInstrumentResponse = (
   idWallet: string


### PR DESCRIPTION
## Short description
This PR fixes the `/wallet/instrument/{walletId}/initiatives` endpoint, which returns the initiatives status for a payment method.

## List of changes proposed in this pull request
- `getInitiativeWithInstrumentResponse` now returns the status of all initiatives and not only for the active initiatives
-  `getWalletById` now has an `enabledFunctions` filters to exclude wallets without BPD capabilities

## How to test
Tests should solve correctly
