### PR TITLE
[IO-558] Add recipientType in the NotificationRecipient payload

### DIFF
--- a/src/features/pn/payloads/messages.ts
+++ b/src/features/pn/payloads/messages.ts
@@ -336,6 +336,7 @@ const createPNMessageRecipient = (
   pipe(
     paymentDataWithRequiredPayee,
     E.map(paymentDataWithRequiredPayee => ({
+      recipientType: "unknownContent",
       taxId: fiscalCode,
       denomination,
       payment: {

--- a/src/features/pn/types/notificationRecipient.ts
+++ b/src/features/pn/types/notificationRecipient.ts
@@ -3,5 +3,6 @@ import { NotificationPaymentInfo } from "./notificationPaymentInfo";
 export type NotificationRecipient = {
   taxId: string;
   denomination: string;
+  recipientType: string;
   payment: NotificationPaymentInfo;
 };


### PR DESCRIPTION
## Short description
This PR adds the `recipientType` in the `NotificationRecipient` payload.

## List of changes proposed in this pull request
- updated type
- updated payload

## How to test
using postman check that the response contains the `recipientType` property
