### PR TITLE
[IOCOM-560] Add category to PaymentProblemJson for payments

### DIFF
--- a/src/persistence/payments.ts
+++ b/src/persistence/payments.ts
@@ -15,10 +15,7 @@ import { PaymentRequestsGetResponse } from "../../generated/definitions/backend/
 import { EnteBeneficiario } from "../../generated/definitions/backend/EnteBeneficiario";
 import { OrganizationName } from "../../generated/definitions/backend/OrganizationName";
 import { RptId } from "../../generated/definitions/backend/RptId";
-import {
-  Detail_v2Enum,
-  PaymentProblemJson
-} from "../../generated/definitions/backend/PaymentProblemJson";
+import { Detail_v2Enum } from "../../generated/definitions/backend/PaymentProblemJson";
 import { CodiceContestoPagamento } from "../../generated/definitions/backend/CodiceContestoPagamento";
 import { Iban } from "../../generated/definitions/backend/Iban";
 import { SpezzoniCausaleVersamentoItem } from "../../generated/definitions/backend/SpezzoniCausaleVersamentoItem";
@@ -27,7 +24,10 @@ import {
   processablePayment,
   processedPayment
 } from "../types/PaymentStatus";
-import { rptIdFromPaymentDataWithRequiredPayee } from "../utils/payment";
+import {
+  detailV2EnumToPaymentProblemJSON,
+  rptIdFromPaymentDataWithRequiredPayee
+} from "../utils/payment";
 
 const paymentData = new Map<string, PaymentDataWithRequiredPayee>();
 const paymentStatuses = new Map<string, PaymentStatus>();
@@ -111,10 +111,8 @@ const createProcessedPayment = (
   details: Detail_v2Enum
 ): PaymentStatus =>
   pipe(
-    {
-      detail: "PAYMENT_UNKNOWN", // Legacy, it is the default value provided
-      detail_v2: details
-    } as PaymentProblemJson,
+    details,
+    detailV2EnumToPaymentProblemJSON,
     processedPayment,
     processedPayment => addOrUpdatePaymentStatus(rptId, processedPayment)
   );

--- a/src/routers/payment.ts
+++ b/src/routers/payment.ts
@@ -8,10 +8,7 @@ import { Iban } from "../../generated/definitions/backend/Iban";
 import { PaymentActivationsGetResponse } from "../../generated/definitions/backend/PaymentActivationsGetResponse";
 import { PaymentActivationsPostRequest } from "../../generated/definitions/backend/PaymentActivationsPostRequest";
 import { PaymentActivationsPostResponse } from "../../generated/definitions/backend/PaymentActivationsPostResponse";
-import {
-  DetailEnum,
-  Detail_v2Enum
-} from "../../generated/definitions/backend/PaymentProblemJson";
+import { Detail_v2Enum } from "../../generated/definitions/backend/PaymentProblemJson";
 import { PaymentRequestsGetResponse } from "../../generated/definitions/backend/PaymentRequestsGetResponse";
 import { ServicePublic } from "../../generated/definitions/backend/ServicePublic";
 import { PaymentResponse } from "../../generated/definitions/pagopa/walletv2/PaymentResponse";
@@ -25,6 +22,7 @@ import { appendWalletV1Prefix } from "../utils/wallet";
 import PaymentsDB from "../persistence/payments";
 import { RptId } from "../../generated/definitions/backend/RptId";
 import { fold } from "../types/PaymentStatus";
+import { detailV2EnumToPaymentProblemJSON } from "../utils/payment";
 import ServicesDB, { ServiceSummary } from "./../persistence/services";
 import { profileRouter } from "./profile";
 import { walletRouter } from "./wallet";
@@ -293,8 +291,4 @@ addHandler(
 addNewRoute("post", "/wallet/v3/webview/transactions/pay");
 
 const legacyResponseWithError = (detailV2: Detail_v2Enum, res: Response) =>
-  res.status(500).json({
-    // deprecated, it is just a placeholder
-    detail: DetailEnum.PAYMENT_UNKNOWN,
-    detail_v2: detailV2
-  });
+  res.status(500).json(detailV2EnumToPaymentProblemJSON(detailV2));

--- a/src/utils/payment.ts
+++ b/src/utils/payment.ts
@@ -1,6 +1,11 @@
 import { pipe } from "fp-ts/lib/function";
 import { PaymentDataWithRequiredPayee } from "../../generated/definitions/backend/PaymentDataWithRequiredPayee";
-import { PaymentProblemJson } from "../../generated/definitions/backend/PaymentProblemJson";
+import {
+  CategoryEnum,
+  DetailEnum,
+  Detail_v2Enum,
+  PaymentProblemJson
+} from "../../generated/definitions/backend/PaymentProblemJson";
 import { RptId } from "../../generated/definitions/backend/RptId";
 import { NotificationPaymentInfo } from "../features/pn/types/notificationPaymentInfo";
 
@@ -73,3 +78,73 @@ export const isPaid = (paymentProblemJSON: PaymentProblemJson) =>
       detail === "PAA_PAGAMENTO_DUPLICATO" ||
       detail === "PPT_PAGAMENTO_DUPLICATO"
   );
+
+export const detailV2EnumToPaymentProblemJSON = (
+  details: Detail_v2Enum
+): PaymentProblemJson => ({
+  detail: DetailEnum.PAYMENT_UNKNOWN, // Legacy, it is the default value provided
+  detail_v2: details,
+  category: detailV2EnumToCategoryEnum(details)
+});
+
+// eslint-disable-next-line complexity
+const detailV2EnumToCategoryEnum = (details: Detail_v2Enum): CategoryEnum => {
+  switch (details) {
+    case Detail_v2Enum.PAA_PAGAMENTO_ANNULLATO:
+      return CategoryEnum.PAYMENT_CANCELED;
+
+    case Detail_v2Enum.PAA_PAGAMENTO_SCADUTO:
+    case Detail_v2Enum.PPT_TOKEN_SCADUTO:
+      return CategoryEnum.PAYMENT_EXPIRED;
+
+    case Detail_v2Enum.PPT_ID_CARRELLO_DUPLICATO:
+    case Detail_v2Enum.PPT_RT_DUPLICATA:
+    case Detail_v2Enum.PPT_RPT_DUPLICATA:
+    case Detail_v2Enum.PAA_PAGAMENTO_DUPLICATO:
+    case Detail_v2Enum.CANALE_RPT_DUPLICATA:
+    case Detail_v2Enum.CANALE_CARRELLO_DUPLICATO_KO:
+    case Detail_v2Enum.CANALE_CARRELLO_DUPLICATO_UNKNOWN:
+    case Detail_v2Enum.CANALE_CARRELLO_DUPLICATO_OK:
+    case Detail_v2Enum.PPT_PAGAMENTO_DUPLICATO:
+      return CategoryEnum.PAYMENT_DUPLICATED;
+
+    case Detail_v2Enum.PAA_PAGAMENTO_IN_CORSO:
+    case Detail_v2Enum.PPT_PAGAMENTO_IN_CORSO:
+      return CategoryEnum.PAYMENT_ONGOING;
+
+    case Detail_v2Enum.PPT_RT_NONDISPONIBILE:
+    case Detail_v2Enum.PPT_FIRMA_INDISPONIBILE:
+    case Detail_v2Enum.PPT_CANALE_INDISPONIBILE:
+    case Detail_v2Enum.PPT_STAZIONE_INT_PA_INDISPONIBILE:
+    case Detail_v2Enum.PAA_FIRMA_INDISPONIBILE:
+    case Detail_v2Enum.CANALE_RT_NON_DISPONIBILE:
+    case Detail_v2Enum.CANALE_INDISPONIBILE:
+      return CategoryEnum.PAYMENT_UNAVAILABLE;
+
+    case Detail_v2Enum.PPT_RPT_SCONOSCIUTA:
+    case Detail_v2Enum.PPT_RT_SCONOSCIUTA:
+    case Detail_v2Enum.PPT_TIPOFIRMA_SCONOSCIUTO:
+    case Detail_v2Enum.PPT_WISP_SESSIONE_SCONOSCIUTA:
+    case Detail_v2Enum.PPT_CODIFICA_PSP_SCONOSCIUTA:
+    case Detail_v2Enum.PPT_PSP_SCONOSCIUTO:
+    case Detail_v2Enum.PPT_TIPO_VERSAMENTO_SCONOSCIUTO:
+    case Detail_v2Enum.PPT_INTERMEDIARIO_PSP_SCONOSCIUTO:
+    case Detail_v2Enum.PPT_CANALE_SCONOSCIUTO:
+    case Detail_v2Enum.PPT_INTERMEDIARIO_PA_SCONOSCIUTO:
+    case Detail_v2Enum.PPT_STAZIONE_INT_PA_SCONOSCIUTA:
+    case Detail_v2Enum.PPT_ID_FLUSSO_SCONOSCIUTO:
+    case Detail_v2Enum.PAA_RPT_SCONOSCIUTA:
+    case Detail_v2Enum.PAA_TIPOFIRMA_SCONOSCIUTO:
+    case Detail_v2Enum.PAA_PAGAMENTO_SCONOSCIUTO:
+    case Detail_v2Enum.CANALE_RPT_SCONOSCIUTA:
+    case Detail_v2Enum.CANALE_RT_SCONOSCIUTA:
+    case Detail_v2Enum.CANALE_FIRMA_SCONOSCIUTA:
+    case Detail_v2Enum.PPT_TOKEN_SCONOSCIUTO:
+    case Detail_v2Enum.PPT_POSIZIONE_SCONOSCIUTA:
+      return CategoryEnum.PAYMENT_UNKNOWN;
+
+    case Detail_v2Enum.PPT_DOMINIO_SCONOSCIUTO:
+      return CategoryEnum.DOMAIN_UNKNOWN;
+  }
+  return CategoryEnum.GENERIC_ERROR;
+};


### PR DESCRIPTION
## Short description
This PR adds the `category` property to `PaymentProblemJson` instances.

## List of changes proposed in this pull request
- Upon `PaymentProblemJson` instance generation, a proper category is generated using the `Detail_v2Enum` instance's value

## How to test
Generate a payment that contains an error or that is already paid and check that the verify endpoint returns a JSON containing the category.
