### PR TITLE
[IOCOM-563] Payment completion tracking through payments' database

### DIFF
--- a/src/payloads/message.ts
+++ b/src/payloads/message.ts
@@ -16,7 +16,6 @@ import {
 } from "../../generated/definitions/backend/MessageCategoryPN";
 import { NewMessageContent } from "../../generated/definitions/backend/NewMessageContent";
 import { PaymentAmount } from "../../generated/definitions/backend/PaymentAmount";
-import { PaymentDataWithRequiredPayee } from "../../generated/definitions/backend/PaymentDataWithRequiredPayee";
 import { PaymentNoticeNumber } from "../../generated/definitions/backend/PaymentNoticeNumber";
 import { PrescriptionData } from "../../generated/definitions/backend/PrescriptionData";
 import { ThirdPartyAttachment } from "../../generated/definitions/backend/ThirdPartyAttachment";
@@ -30,9 +29,10 @@ import { thirdPartyMessagePreconditionMarkdown } from "../utils/variables";
 import { ThirdPartyMessagePrecondition } from "../../generated/definitions/backend/ThirdPartyMessagePrecondition";
 import { ServicePublic } from "../../generated/definitions/backend/ServicePublic";
 import { FiscalCode } from "../../generated/definitions/backend/FiscalCode";
-import { OrganizationFiscalCode } from "../../generated/definitions/backend/OrganizationFiscalCode";
 import { pnServiceId } from "../features/pn/services/services";
+import { rptIdFromPaymentDataWithRequiredPayee } from "../utils/payment";
 import ServicesDB from "./../persistence/services";
+import PaymentsDB from "./../persistence/payments";
 
 // eslint-disable-next-line functional/no-let
 let messageIdIndex = 0;
@@ -85,25 +85,6 @@ export const withRemoteAttachments = (
   }
 });
 
-export const generatePaymentData = (
-  organizationFiscalCode: OrganizationFiscalCode,
-  invalidAfterDueDate: boolean = false,
-  noticeNumber: string = `0${faker.random.numeric(17)}`,
-  amount: number = getRandomIntInRange(1, 10000)
-) =>
-  pipe(
-    {
-      notice_number: noticeNumber as PaymentNoticeNumber,
-      amount: amount as PaymentAmount,
-      invalid_after_due_date: invalidAfterDueDate,
-      payee: {
-        fiscal_code: organizationFiscalCode
-      }
-    },
-    (data: PaymentDataWithRequiredPayee) =>
-      validatePayload(PaymentDataWithRequiredPayee, data)
-  );
-
 const serviceFromMessage = (
   message: CreatedMessageWithContent
 ): E.Either<Error, Readonly<ServicePublic>> =>
@@ -128,18 +109,34 @@ export const withPaymentData = (
   pipe(
     message,
     serviceFromMessage,
-    E.map(service =>
+    E.chain(service =>
       pipe(
-        generatePaymentData(
+        PaymentsDB.createPaymentData(
           service.organization_fiscal_code,
           invalidAfterDueDate,
-          noticeNumber,
-          amount
+          noticeNumber as PaymentNoticeNumber,
+          amount as PaymentAmount
         ),
-        payment_data => ({
-          ...message,
-          content: { ...message.content, payment_data }
-        })
+        E.map(paymentDataWithRequiredPayee =>
+          pipe(
+            PaymentsDB.createProcessablePayment(
+              rptIdFromPaymentDataWithRequiredPayee(
+                paymentDataWithRequiredPayee
+              ),
+              amount as PaymentAmount,
+              service.organization_fiscal_code,
+              service.organization_name
+            ),
+            _ => ({
+              ...message,
+              content: {
+                ...message.content,
+                payment_data: paymentDataWithRequiredPayee
+              }
+            })
+          )
+        ),
+        E.mapLeft(errors => Error(errors.join("\n")))
       )
     )
   );

--- a/src/routers/payment.ts
+++ b/src/routers/payment.ts
@@ -196,7 +196,11 @@ addHandler(
   "get",
   appendWalletV1Prefix("/payments/:idPagamento/actions/check"),
   (_, res) => {
-    if (idPagamento === undefined || paymentRequest === undefined || O.isNone(paymentRptId)) {
+    if (
+      idPagamento === undefined ||
+      paymentRequest === undefined ||
+      O.isNone(paymentRptId)
+    ) {
       res.sendStatus(404);
       return;
     }
@@ -265,20 +269,23 @@ addHandler(
   walletRouter,
   "post",
   "/wallet/v3/webview/transactions/pay",
-  (req, res) => 
-    pipe(
-      ioDevServerConfig.wallet.paymentOutCode,
-      paymentOutCode => 
-        pipe(
-          paymentRptId,
-          O.filter(_ => paymentOutCode === 0 && !ioDevServerConfig.wallet.useLegacyRptIdVerificationSystem),
-          O.map(rptId => PaymentsDB.createProcessedPayment(rptId, Detail_v2Enum.PPT_PAGAMENTO_DUPLICATO)),
-          _ => handlePaymentPostAndRedirect(
-            req,
-            res,
-            paymentOutCode
+  (req, res) =>
+    pipe(ioDevServerConfig.wallet.paymentOutCode, paymentOutCode =>
+      pipe(
+        paymentRptId,
+        O.filter(
+          _ =>
+            paymentOutCode === 0 &&
+            !ioDevServerConfig.wallet.useLegacyRptIdVerificationSystem
+        ),
+        O.map(rptId =>
+          PaymentsDB.createProcessedPayment(
+            rptId,
+            Detail_v2Enum.PPT_PAGAMENTO_DUPLICATO
           )
-        )
+        ),
+        _ => handlePaymentPostAndRedirect(req, res, paymentOutCode)
+      )
     )
 );
 


### PR DESCRIPTION
## Short description
This PR adds successful payment tracking and storing in the in-memory payments' database.

## List of changes proposed in this pull request
- Payments generation on messages stores the processable payment into the payments' database
- Payments processing updates a successful payment in the payments' database (through the payments' routing)

## How to test
Try to pay a message's payment and check that the process succeeds. Upon completion, try to pay the same payment again. An "already-paid" error should be reported
