### PR TITLE
[IOCOM-686] Add message generation with remote content

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,15 @@ const defaultConfig: IoDevServerConfig = {
       getMessageResponseCode: 200,
       getThirdPartyMessageResponseCode: 200
     },
+    messageTemplateWrappers: [
+      {
+        count: 1,
+        template: {
+          hasRemoteContent: true,
+          attachmentCount: 5
+        }
+      }
+    ],
     pnMessageTemplateWrappers: [
       {
         count: 0,
@@ -92,7 +101,7 @@ const defaultConfig: IoDevServerConfig = {
     attachmentExpiredAfterSeconds: 10,
     attachmentRetryAfterSeconds: 2,
     pnOptInMessage: false,
-    withRemoteAttachments: 0,
+    withRemoteAttachments: 1,
     paymentsCount: 1,
     paymentInvalidAfterDueDateWithValidDueDateCount: 0,
     paymentInvalidAfterDueDateWithExpiredDueDateCount: 0,

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,7 +101,6 @@ const defaultConfig: IoDevServerConfig = {
     attachmentExpiredAfterSeconds: 10,
     attachmentRetryAfterSeconds: 2,
     pnOptInMessage: false,
-    withRemoteAttachments: 1,
     paymentsCount: 1,
     paymentInvalidAfterDueDateWithValidDueDateCount: 0,
     paymentInvalidAfterDueDateWithExpiredDueDateCount: 0,

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,6 +77,7 @@ const defaultConfig: IoDevServerConfig = {
       {
         count: 1,
         template: {
+          subjectWordCount: 5,
           hasRemoteContent: true,
           attachmentCount: 5
         }

--- a/src/features/messages/persistence/messagesPayload.ts
+++ b/src/features/messages/persistence/messagesPayload.ts
@@ -73,7 +73,8 @@ export const withRemoteContent = (
     ...message.content,
     third_party_data: {
       ...message.content.third_party_data,
-      id: message.id as NonEmptyString
+      id: message.id as NonEmptyString,
+      has_attachments: true
     }
   },
   third_party_message: {

--- a/src/features/messages/persistence/messagesPayload.ts
+++ b/src/features/messages/persistence/messagesPayload.ts
@@ -63,24 +63,6 @@ export const withDueDate = (
   content: { ...message.content, due_date: dueDate }
 });
 
-export const withRemoteAttachments = (
-  message: CreatedMessageWithContent,
-  attachmentCount: number
-): ThirdPartyMessageWithContent => ({
-  ...message,
-  content: {
-    ...message.content,
-    third_party_data: {
-      ...message.content.third_party_data,
-      id: message.id as NonEmptyString,
-      has_attachments: true
-    }
-  },
-  third_party_message: {
-    attachments: getRemoteAttachments(attachmentCount)
-  }
-});
-
 export const withRemoteContent = (
   template: MessageTemplate,
   message: CreatedMessageWithContent,

--- a/src/features/messages/persistence/messagesPayload.ts
+++ b/src/features/messages/persistence/messagesPayload.ts
@@ -74,7 +74,7 @@ export const withRemoteContent = (
     third_party_data: {
       ...message.content.third_party_data,
       id: message.id as NonEmptyString,
-      has_attachments: true
+      has_attachments: template.attachmentCount > 0
     }
   },
   third_party_message: {

--- a/src/features/messages/persistence/messagesPayload.ts
+++ b/src/features/messages/persistence/messagesPayload.ts
@@ -80,7 +80,7 @@ export const withRemoteContent = (
     details: pipe(
       template.hasRemoteContent,
       B.fold(constUndefined, () => ({
-        subject: "#### Remote subject ####",
+        subject: faker.lorem.sentence(template.subjectWordCount),
         markdown
       }))
     ),

--- a/src/features/messages/services/messagesService.ts
+++ b/src/features/messages/services/messagesService.ts
@@ -83,7 +83,7 @@ const getPublicMessages = (
       B.fold(
         () => ({}),
         () => {
-          const { content, is_read, is_archived } =
+          const { content, is_read, is_archived, has_attachments } =
             message as CreatedMessageWithContentAndEnrichedData;
 
           return {
@@ -93,6 +93,7 @@ const getPublicMessages = (
             category: getMessageCategory(message),
             is_read,
             is_archived,
+            has_attachments,
             has_precondition: senderService.service_id === pnServiceId
           };
         }

--- a/src/features/messages/services/messagesService.ts
+++ b/src/features/messages/services/messagesService.ts
@@ -83,7 +83,7 @@ const getPublicMessages = (
       B.fold(
         () => ({}),
         () => {
-          const { content, is_read, is_archived, has_attachments } =
+          const { content, is_read, is_archived } =
             message as CreatedMessageWithContentAndEnrichedData;
 
           return {
@@ -93,7 +93,6 @@ const getPublicMessages = (
             category: getMessageCategory(message),
             is_read,
             is_archived,
-            has_attachments,
             has_precondition: senderService.service_id === pnServiceId
           };
         }

--- a/src/features/messages/types/messageTemplate.ts
+++ b/src/features/messages/types/messageTemplate.ts
@@ -1,7 +1,12 @@
 import * as t from "io-ts";
 
-export const MessageTemplate = t.type({
-  hasRemoteContent: t.boolean,
-  attachmentCount: t.number
-});
+export const MessageTemplate = t.intersection([
+  t.type({
+    hasRemoteContent: t.boolean,
+    attachmentCount: t.number
+  }),
+  t.partial({
+    subjectWordCount: t.number
+  })
+]);
 export type MessageTemplate = t.TypeOf<typeof MessageTemplate>;

--- a/src/features/messages/types/messageTemplate.ts
+++ b/src/features/messages/types/messageTemplate.ts
@@ -1,0 +1,7 @@
+import * as t from "io-ts";
+
+export const MessageTemplate = t.type({
+  hasRemoteContent: t.boolean,
+  attachmentCount: t.number
+});
+export type MessageTemplate = t.TypeOf<typeof MessageTemplate>;

--- a/src/features/messages/types/messageTemplateWrapper.ts
+++ b/src/features/messages/types/messageTemplateWrapper.ts
@@ -1,0 +1,8 @@
+import * as t from "io-ts";
+import { MessageTemplate } from "./messageTemplate";
+
+export const MessageTemplateWrapper = t.type({
+  template: MessageTemplate,
+  count: t.number
+});
+export type MessageTemplateWrapper = t.TypeOf<typeof MessageTemplateWrapper>;

--- a/src/features/messages/types/messagesConfig.ts
+++ b/src/features/messages/types/messagesConfig.ts
@@ -17,8 +17,6 @@ export const MessagesConfig = t.intersection([
       getThirdPartyMessageResponseCode: HttpResponseCode
     }),
     paymentsCount: t.number,
-    // number of messages with remote attachments
-    withRemoteAttachments: t.number,
     // number of message - invalid after due date - containing a payment and a valid (not expired) due date
     paymentInvalidAfterDueDateWithValidDueDateCount: t.number,
     // number of message - invalid after due date -  containing a payment and a not valid (expired) due date

--- a/src/features/messages/types/messagesConfig.ts
+++ b/src/features/messages/types/messagesConfig.ts
@@ -3,6 +3,7 @@ import { PNMessageTemplateWrapper } from "../../pn/types/messageTemplateWrapper"
 import { HttpResponseCode } from "../../../types/httpResponseCode";
 import { AllowRandomValue } from "../../../types/allowRandomValue";
 import { LiveModeMessages } from "./liveModeMessages";
+import { MessageTemplateWrapper } from "./messageTemplateWrapper";
 
 export const MessagesConfig = t.intersection([
   t.type({
@@ -61,6 +62,8 @@ export const MessagesConfig = t.intersection([
     attachmentAvailableAfterSeconds: t.number,
     attachmentExpiredAfterSeconds: t.number,
     attachmentRetryAfterSeconds: t.number,
+    // number of messages with remote content
+    messageTemplateWrappers: t.readonlyArray(MessageTemplateWrapper),
     // number of messages coming from PN (aka Piattaforma Notifiche)
     pnMessageTemplateWrappers: t.readonlyArray(PNMessageTemplateWrapper),
     // PN Opt In message

--- a/src/populate-persistence.ts
+++ b/src/populate-persistence.ts
@@ -20,8 +20,7 @@ import {
   withContent,
   withDueDate,
   withPaymentData,
-  withRemoteContent,
-  withRemoteAttachments
+  withRemoteContent
 } from "./features/messages/persistence/messagesPayload";
 import ServicesDB from "./persistence/services";
 import MessagesDB from "./features/messages/persistence/messagesDatabase";
@@ -86,22 +85,6 @@ export const getNewMessage = (
     markdown,
     prescriptionData,
     euCovidCert
-  );
-
-const getNewRemoteAttachmentsMessage = (
-  customConfig: IoDevServerConfig,
-  sender: string,
-  subject: string,
-  markdown: string,
-  attachmentCount: number
-): ThirdPartyMessageWithContent =>
-  withRemoteAttachments(
-    withContent(
-      createMessage(customConfig.profile.attrs.fiscal_code, getServiceId()),
-      `${sender}: ${subject}`,
-      markdown
-    ),
-    attachmentCount
   );
 
 const createMessagesWithCTA = (
@@ -476,19 +459,6 @@ const createMessagesWithPayments = (
     )
   );
 
-const createMessagesWithRemoteAttachments = (
-  customConfig: IoDevServerConfig
-): CreatedMessageWithContentAndAttachments[] =>
-  A.makeBy(customConfig.messages.withRemoteAttachments, index =>
-    getNewRemoteAttachmentsMessage(
-      customConfig,
-      `Sender ${index}`,
-      `Subject ${index}: remote attachments`,
-      messageMarkdown,
-      1 + index
-    )
-  );
-
 const createMessageWithRemoteContent = (
   template: MessageTemplate,
   fiscalCode: FiscalCode,
@@ -597,7 +567,6 @@ const createMessages = (
     ...createPNOptInMessage(customConfig),
     ...createPNMessages(customConfig),
 
-    ...createMessagesWithRemoteAttachments(customConfig),
     ...createMessagesWithRemoteContent(customConfig)
   ];
 };

--- a/src/routers/__tests__/message.test.ts
+++ b/src/routers/__tests__/message.test.ts
@@ -44,7 +44,6 @@ const customConfig = _.merge(ioDevServerConfig, {
     withInValidDueDateCount: 2,
     standardMessageCount: 10,
     archivedMessageCount: 40,
-    withRemoteAttachments: 0,
     pnMessageTemplateWrappers: [
       {
         count: 1,


### PR DESCRIPTION
## Short description
This PR allows to generate messages with remote content.

## List of changes proposed in this pull request
- `src/config`: added configuration for messages with remote content
- `src/populate-persistence.ts`: added generation of messages with remote content (saved in-memory)
- `src/features/messages/persistence/messagesPayload.ts`: added `withRemoteContent` function that adds remote content to the message

## How to test
Run the server instance with different configurations and check that the payload returned by the `/messages/:id` and `/third-party-messages/:id` endpoints is correct
