### PR TITLE
[IOBP-309,IOBP-312] Add ability to generate failure for payment verification and activation requests

### DIFF
--- a/src/features/wallet/routers/payment.ts
+++ b/src/features/wallet/routers/payment.ts
@@ -10,7 +10,6 @@ import { RequestAuthorizationResponse } from "../../../../generated/definitions/
 import { RptId } from "../../../../generated/definitions/pagopa/ecommerce/RptId";
 import { ValidationFaultEnum } from "../../../../generated/definitions/pagopa/ecommerce/ValidationFault";
 import { ioDevServerConfig } from "../../../config";
-import { getRandomEnumValue } from "../../../payloads/utils/random";
 import { serverUrl } from "../../../utils/server";
 import { getPaymentRequestsGetResponse } from "../payloads/payments";
 import {
@@ -53,10 +52,7 @@ addPaymentHandler("get", "/payment-requests/:rpt_id", (req, res) =>
                 )
               ),
             failure =>
-              res.status(getStatusCodeForWalletFailure(failure)).json({
-                faultCodeCategory: getRandomEnumValue(FaultCategoryEnum),
-                faultCodeDetail: failure
-              })
+              res.status(getStatusCodeForWalletFailure(failure)).json(failure)
           )
         )
     )

--- a/src/features/wallet/types/configuration.ts
+++ b/src/features/wallet/types/configuration.ts
@@ -1,0 +1,8 @@
+import * as t from "io-ts";
+import { WalletPaymentFailure } from "./failure";
+
+export const WalletConfiguration = t.partial({
+  verificationFailure: WalletPaymentFailure
+});
+
+export type WalletConfiguration = t.TypeOf<typeof WalletConfiguration>;

--- a/src/features/wallet/types/configuration.ts
+++ b/src/features/wallet/types/configuration.ts
@@ -2,7 +2,8 @@ import * as t from "io-ts";
 import { WalletPaymentFailure } from "./failure";
 
 export const WalletConfiguration = t.partial({
-  verificationFailure: WalletPaymentFailure
+  verificationFailure: WalletPaymentFailure,
+  activationFailure: WalletPaymentFailure
 });
 
 export type WalletConfiguration = t.TypeOf<typeof WalletConfiguration>;

--- a/src/features/wallet/types/failure.ts
+++ b/src/features/wallet/types/failure.ts
@@ -5,6 +5,13 @@ import { PartyTimeoutFault } from "../../../../generated/definitions/pagopa/ecom
 import { PaymentStatusFault } from "../../../../generated/definitions/pagopa/ecommerce/PaymentStatusFault";
 import { ValidationFault } from "../../../../generated/definitions/pagopa/ecommerce/ValidationFault";
 
+export type WalletPaymentFailureType =
+  | ValidationFault
+  | PaymentStatusFault
+  | GatewayFault
+  | PartyConfigurationFault
+  | PartyTimeoutFault;
+
 export type WalletPaymentFailure = t.TypeOf<typeof WalletPaymentFailure>;
 export const WalletPaymentFailure = t.union([
   ValidationFault,
@@ -15,12 +22,7 @@ export const WalletPaymentFailure = t.union([
 ]);
 
 export const getStatusCodeForWalletFailure = (
-  failure:
-    | ValidationFault
-    | PaymentStatusFault
-    | GatewayFault
-    | PartyConfigurationFault
-    | PartyTimeoutFault
+  failure: WalletPaymentFailureType
 ): 404 | 409 | 502 | 503 | 504 => {
   if (ValidationFault.is(failure)) {
     return 404;

--- a/src/features/wallet/types/failure.ts
+++ b/src/features/wallet/types/failure.ts
@@ -1,36 +1,29 @@
 import * as t from "io-ts";
-import { GatewayFault } from "../../../../generated/definitions/pagopa/ecommerce/GatewayFault";
-import { PartyConfigurationFault } from "../../../../generated/definitions/pagopa/ecommerce/PartyConfigurationFault";
-import { PartyTimeoutFault } from "../../../../generated/definitions/pagopa/ecommerce/PartyTimeoutFault";
-import { PaymentStatusFault } from "../../../../generated/definitions/pagopa/ecommerce/PaymentStatusFault";
-import { ValidationFault } from "../../../../generated/definitions/pagopa/ecommerce/ValidationFault";
-
-export type WalletPaymentFailureType =
-  | ValidationFault
-  | PaymentStatusFault
-  | GatewayFault
-  | PartyConfigurationFault
-  | PartyTimeoutFault;
+import { GatewayFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/GatewayFaultPaymentProblemJson";
+import { PartyConfigurationFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/PartyConfigurationFaultPaymentProblemJson";
+import { PartyTimeoutFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/PartyTimeoutFaultPaymentProblemJson";
+import { PaymentStatusFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/PaymentStatusFaultPaymentProblemJson";
+import { ValidationFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/ValidationFaultPaymentProblemJson";
 
 export type WalletPaymentFailure = t.TypeOf<typeof WalletPaymentFailure>;
 export const WalletPaymentFailure = t.union([
-  ValidationFault,
-  PaymentStatusFault,
-  GatewayFault,
-  PartyConfigurationFault,
-  PartyTimeoutFault
+  ValidationFaultPaymentProblemJson,
+  PaymentStatusFaultPaymentProblemJson,
+  GatewayFaultPaymentProblemJson,
+  PartyConfigurationFaultPaymentProblemJson,
+  PartyTimeoutFaultPaymentProblemJson
 ]);
 
 export const getStatusCodeForWalletFailure = (
-  failure: WalletPaymentFailureType
+  failure: WalletPaymentFailure
 ): 404 | 409 | 502 | 503 | 504 => {
-  if (ValidationFault.is(failure)) {
+  if (ValidationFaultPaymentProblemJson.is(failure)) {
     return 404;
-  } else if (PaymentStatusFault.is(failure)) {
+  } else if (PaymentStatusFaultPaymentProblemJson.is(failure)) {
     return 409;
-  } else if (GatewayFault.is(failure)) {
+  } else if (GatewayFaultPaymentProblemJson.is(failure)) {
     return 502;
-  } else if (PartyConfigurationFault.is(failure)) {
+  } else if (PartyConfigurationFaultPaymentProblemJson.is(failure)) {
     return 503;
   } else {
     return 504;

--- a/src/features/wallet/types/failure.ts
+++ b/src/features/wallet/types/failure.ts
@@ -1,15 +1,36 @@
 import * as t from "io-ts";
-import { GatewayFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/GatewayFaultPaymentProblemJson";
-import { PartyConfigurationFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/PartyConfigurationFaultPaymentProblemJson";
-import { PartyTimeoutFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/PartyTimeoutFaultPaymentProblemJson";
-import { PaymentStatusFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/PaymentStatusFaultPaymentProblemJson";
-import { ValidationFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/ValidationFaultPaymentProblemJson";
+import { GatewayFault } from "../../../../generated/definitions/pagopa/ecommerce/GatewayFault";
+import { PartyConfigurationFault } from "../../../../generated/definitions/pagopa/ecommerce/PartyConfigurationFault";
+import { PartyTimeoutFault } from "../../../../generated/definitions/pagopa/ecommerce/PartyTimeoutFault";
+import { PaymentStatusFault } from "../../../../generated/definitions/pagopa/ecommerce/PaymentStatusFault";
+import { ValidationFault } from "../../../../generated/definitions/pagopa/ecommerce/ValidationFault";
 
 export type WalletPaymentFailure = t.TypeOf<typeof WalletPaymentFailure>;
 export const WalletPaymentFailure = t.union([
-  ValidationFaultPaymentProblemJson,
-  PaymentStatusFaultPaymentProblemJson,
-  GatewayFaultPaymentProblemJson,
-  PartyConfigurationFaultPaymentProblemJson,
-  PartyTimeoutFaultPaymentProblemJson
+  ValidationFault,
+  PaymentStatusFault,
+  GatewayFault,
+  PartyConfigurationFault,
+  PartyTimeoutFault
 ]);
+
+export const getStatusCodeForWalletFailure = (
+  failure:
+    | ValidationFault
+    | PaymentStatusFault
+    | GatewayFault
+    | PartyConfigurationFault
+    | PartyTimeoutFault
+): 404 | 409 | 502 | 503 | 504 => {
+  if (ValidationFault.is(failure)) {
+    return 404;
+  } else if (PaymentStatusFault.is(failure)) {
+    return 409;
+  } else if (GatewayFault.is(failure)) {
+    return 502;
+  } else if (PartyConfigurationFault.is(failure)) {
+    return 503;
+  } else {
+    return 504;
+  }
+};

--- a/src/features/wallet/types/failure.ts
+++ b/src/features/wallet/types/failure.ts
@@ -1,0 +1,15 @@
+import * as t from "io-ts";
+import { GatewayFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/GatewayFaultPaymentProblemJson";
+import { PartyConfigurationFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/PartyConfigurationFaultPaymentProblemJson";
+import { PartyTimeoutFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/PartyTimeoutFaultPaymentProblemJson";
+import { PaymentStatusFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/PaymentStatusFaultPaymentProblemJson";
+import { ValidationFaultPaymentProblemJson } from "../../../../generated/definitions/pagopa/ecommerce/ValidationFaultPaymentProblemJson";
+
+export type WalletPaymentFailure = t.TypeOf<typeof WalletPaymentFailure>;
+export const WalletPaymentFailure = t.union([
+  ValidationFaultPaymentProblemJson,
+  PaymentStatusFaultPaymentProblemJson,
+  GatewayFaultPaymentProblemJson,
+  PartyConfigurationFaultPaymentProblemJson,
+  PartyTimeoutFaultPaymentProblemJson
+]);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -14,8 +14,9 @@ import { PreferredLanguages } from "../../generated/definitions/backend/Preferre
 import { PushNotificationsContentType } from "../../generated/definitions/backend/PushNotificationsContentType";
 import { ReminderStatus } from "../../generated/definitions/backend/ReminderStatus";
 import { MessagesConfig } from "../features/messages/types/messagesConfig";
-import { HttpResponseCode } from "./httpResponseCode";
+import { WalletConfiguration } from "../features/wallet/types/configuration";
 import { AllowRandomValue } from "./allowRandomValue";
+import { HttpResponseCode } from "./httpResponseCode";
 
 /* profile */
 export const ProfileAttrs = t.intersection([
@@ -210,6 +211,9 @@ export const IoDevServerConfig = t.interface({
           assertionRefValidityMS: t.number
         })
       ])
+    }),
+    t.partial({
+      wallet: WalletConfiguration
     }),
     t.partial({
       fastLogin: t.interface({


### PR DESCRIPTION
## Short description
This PR adds the ability to force a failure during the payment verification and activation request.

## How to test
- To simulate a failure during the verification request, add the following configuration in your config.json :
  ```json
   "features": {
      "wallet": {
        "verificationFailure": {
          "faultCodeCategory": "PAYMENT_UNAVAILABLE",
          "faultCodeDetail":"PPT_PSP_SCONOSCIUTO"
        }
      }
    }
    ```
  Check that the `GET /payment-requests/:rpt_id` endpoint returns a failure
  
 -  To simulate a failure during the activation request, add the following configuration in your config.json :
    ```json
     "features": {
        "wallet": {
          "activationFailure": {
            "faultCodeCategory": "PAYMENT_UNAVAILABLE",
            "faultCodeDetail":"PPT_PSP_SCONOSCIUTO"
          }
        }
      }
     ```
    Check that the `POST /transaction` endpoint returns a failure