### PR TITLE
chore: [IOBP-555] Add payment outcome 15 and 17 into html page

### DIFF
--- a/assets/wallet/wallet_payment.html
+++ b/assets/wallet/wallet_payment.html
@@ -18,7 +18,9 @@
             ["11", "ORDER_NOT_PRESENT"],
             ["12", "INVALID_METHOD"],
             ["13", "KO_RETRIABLE"],
-            ["14", "INVALID_SESSION"]
+            ["14", "INVALID_SESSION"],
+            ["15", "METHOD_NOT_ENABLED"],
+            ["17", "WAITING_CONFIRMATION_EMAIL"],
         ];
 
         const simulateOutcome = () => {


### PR DESCRIPTION
## Short description
This PR adds to the HTML page mock two more outcomes: 
- Outcome `15` - METHOD_NOT_ENABLED
- Outcome `17` - WAITING_CONFIRMATION_EMAIL

## List of changes proposed in this pull request
- Added inside the outcome list from wallet_payment.html the two new outcomes

