### PR TITLE
[IOPAE-1117] Add services `/featured` api mock

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -191,6 +191,7 @@ const defaultConfig: IoDevServerConfig = {
     },
     service: {
       response: {
+        featuredItemsResponseCode: 200,
         institutionsResponseCode: 200
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -190,6 +190,7 @@ const defaultConfig: IoDevServerConfig = {
       sessionTTLinMS: 60000
     },
     service: {
+      featuredItemsSize: 5,
       response: {
         featuredItemsResponseCode: 200,
         institutionsResponseCode: 200

--- a/src/features/services/payloads/get-featured-items.ts
+++ b/src/features/services/payloads/get-featured-items.ts
@@ -52,13 +52,13 @@ export const getFeaturedItemsResponsePayload = (): FeaturedItems => {
   );
 
   // returns randomly ordered featured items
-  const featuredItems = pipe(
+  const featuredItems = _.sampleSize(
     [
       ...featuredSpecialServices,
       ...featuredIntitutions,
       ...featuredNationalServices
     ],
-    arr => _.sampleSize(arr, featuredItemsSize)
+    featuredItemsSize
   );
 
   return {

--- a/src/features/services/payloads/get-featured-items.ts
+++ b/src/features/services/payloads/get-featured-items.ts
@@ -1,11 +1,14 @@
 import { nonEmptyArray } from "fp-ts";
-import * as A from "fp-ts/Array";
+import * as A from "fp-ts/lib/Array";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import { FeaturedItem } from "../../../../generated/definitions/services/FeaturedItem";
 import { FeaturedItems } from "../../../../generated/definitions/services/FeaturedItems";
+import { ioDevServerConfig } from "../../../config";
 import ServicesDB from "../../../persistence/services";
 import { getInstitutionsResponsePayload } from "./get-institutions";
+
+const featuredItemsSize = ioDevServerConfig.features.service.featuredItemsSize;
 
 /**
  * Returns a random ordered array subset.
@@ -16,7 +19,7 @@ import { getInstitutionsResponsePayload } from "./get-institutions";
 const getRandomArraySubset = <T>(array: T[], size: number): T[] =>
   pipe(
     O.some(array),
-    O.fromPredicate(arr => O.isSome(arr) && size <= array.length),
+    O.fromPredicate(arr => O.isSome(arr) && size > 0 && size <= array.length),
     O.fold(
       () => [],
       () => {
@@ -92,7 +95,7 @@ export const getFeaturedItemsResponsePayload = (): FeaturedItems => {
       ...featuredIntitutions,
       ...featuredNationalServices
     ],
-    arr => getRandomArraySubset(arr, arr.length)
+    arr => getRandomArraySubset(arr, featuredItemsSize)
   );
 
   return {

--- a/src/features/services/payloads/get-featured-items.ts
+++ b/src/features/services/payloads/get-featured-items.ts
@@ -1,0 +1,101 @@
+import { nonEmptyArray } from "fp-ts";
+import * as A from "fp-ts/Array";
+import * as O from "fp-ts/lib/Option";
+import { pipe } from "fp-ts/lib/function";
+import { FeaturedItem } from "../../../../generated/definitions/services/FeaturedItem";
+import { FeaturedItems } from "../../../../generated/definitions/services/FeaturedItems";
+import ServicesDB from "../../../persistence/services";
+import { getInstitutionsResponsePayload } from "./get-institutions";
+
+/**
+ * Returns a random ordered array subset.
+ * @param array starting array of type T
+ * @param size array subset size (if `size` greater than `array`, it returns empty array subset)
+ * @returns
+ */
+const getRandomArraySubset = <T>(array: T[], size: number): T[] =>
+  pipe(
+    O.some(array),
+    O.fromPredicate(arr => O.isSome(arr) && size <= array.length),
+    O.fold(
+      () => [],
+      () => {
+        const remainingItems = [...array];
+        return pipe(
+          nonEmptyArray.range(1, size),
+          A.map(() => {
+            const randomIndex = Math.floor(
+              Math.random() * remainingItems.length
+            );
+            const selectedItem = remainingItems[randomIndex];
+            // eslint-disable-next-line functional/immutable-data
+            remainingItems.splice(randomIndex, 1);
+            return selectedItem;
+          })
+        );
+      }
+    )
+  );
+
+export const getFeaturedItemsResponsePayload = (): FeaturedItems => {
+  // take some casual national service
+  const selectedNationalServices = getRandomArraySubset(
+    ServicesDB.getNationalServices(),
+    1
+  );
+  // take some casual special service
+  const selectedSpecialServices = getRandomArraySubset(
+    ServicesDB.getSpecialServices(),
+    3
+  );
+  // take some casual institutions
+  const featuredIntitutions = getRandomArraySubset(
+    Array.from(getInstitutionsResponsePayload().institutions),
+    1
+  );
+
+  /**
+   * Reduced national services to FeaturedService[] (add organization_name for layout testing purpose)
+   */
+  const featuredNationalServices: FeaturedItem[] = pipe(
+    selectedNationalServices,
+    A.reduce([] as FeaturedItem[], (accumulator, service) => [
+      ...accumulator,
+      {
+        id: service.service_id,
+        name: service.service_name,
+        version: service.version,
+        organization_name: service.organization_name
+      }
+    ])
+  );
+
+  /**
+   * Reduce special services to FeaturedService[]
+   */
+  const featuredSpecialServices: FeaturedItem[] = pipe(
+    selectedSpecialServices,
+    A.reduce([] as FeaturedItem[], (accumulator, service) => [
+      ...accumulator,
+      {
+        id: service.service_id,
+        name: service.service_name,
+        version: service.version
+      }
+    ])
+  );
+
+  // returns randomly ordered featured items
+  const featuredItems = pipe(
+    [
+      ...featuredSpecialServices,
+      ...featuredIntitutions,
+      ...featuredNationalServices
+    ],
+    arr => getRandomArraySubset(arr, arr.length)
+  );
+
+  return {
+    items: featuredItems
+  };
+};

--- a/src/features/services/routers/featured.ts
+++ b/src/features/services/routers/featured.ts
@@ -1,0 +1,27 @@
+import * as O from "fp-ts/lib/Option";
+import { pipe } from "fp-ts/lib/function";
+import { ioDevServerConfig } from "../../../config";
+import { addHandler } from "../../../payloads/response";
+import { getFeaturedItemsResponsePayload } from "../payloads/get-featured-items";
+import { addApiV2Prefix, serviceRouter } from "./router";
+
+const serviceConfig = ioDevServerConfig.features.service;
+
+// Retrieve featured items
+addHandler(serviceRouter, "get", addApiV2Prefix("/featured"), (_, res) =>
+  pipe(
+    serviceConfig.response.featuredItemsResponseCode,
+    O.fromPredicate(statusCode => statusCode !== 200),
+    O.fold(
+      () =>
+        pipe(
+          O.of(getFeaturedItemsResponsePayload()),
+          O.fold(
+            () => res.status(404),
+            featuredItems => res.status(200).json(featuredItems)
+          )
+        ),
+      statusCode => res.sendStatus(statusCode)
+    )
+  )
+);

--- a/src/features/services/routers/index.ts
+++ b/src/features/services/routers/index.ts
@@ -1,3 +1,4 @@
+import "./featured";
 import "./institutions";
 
 export { serviceRouter } from "./router";

--- a/src/features/services/types/configuration.ts
+++ b/src/features/services/types/configuration.ts
@@ -5,6 +5,7 @@ export const ServiceConfiguration = t.interface({
   // configure some API response error code
   response: t.interface({
     // 200 success with payload
+    featuredItemsResponseCode: HttpResponseCode,
     institutionsResponseCode: HttpResponseCode
   })
 });

--- a/src/features/services/types/configuration.ts
+++ b/src/features/services/types/configuration.ts
@@ -1,9 +1,12 @@
+import { WithinRangeNumber } from "@pagopa/ts-commons/lib/numbers";
 import * as t from "io-ts";
 import { HttpResponseCode } from "../../../types/httpResponseCode";
 
-export const ServiceConfiguration = t.interface({
+export const ServiceConfiguration = t.type({
+  // configure number of featured items
+  featuredItemsSize: WithinRangeNumber(0, 6),
   // configure some API response error code
-  response: t.interface({
+  response: t.type({
     // 200 success with payload
     featuredItemsResponseCode: HttpResponseCode,
     institutionsResponseCode: HttpResponseCode

--- a/src/persistence/services.ts
+++ b/src/persistence/services.ts
@@ -97,6 +97,8 @@ const getAllServices = () => [
 ];
 
 const getLocalServices = () => localServices.map(ls => ({ ...ls }));
+const getNationalServices = () => nationalServices.map(ls => ({ ...ls }));
+const getSpecialServices = () => specialServices.map(ls => ({ ...ls }));
 
 const getPreference = (
   serviceId: ServiceId
@@ -166,6 +168,8 @@ export default {
   deleteServices,
   getAllServices,
   getLocalServices,
+  getNationalServices,
+  getSpecialServices,
   getPreference,
   getService,
   getSummaries,


### PR DESCRIPTION
## Short description
Added new `/featured` api mock implementation that returns a list of highlighted _services_ and/or _institutions_.
_**FeaturedItems Api**_ returns a list with max 5 items _(this size is configurable through the `ioDevServerConfig.features.service.featuredItemsSize` parameter)_. 

## List of changes proposed in this pull request
- Follow commit for details

## How to test
Check api locally by calling `http://192.168.1.172:3000/api/v2/featured`.
