### PR TITLE
[IOPID-92] Add logic to use lollipop in test login

### DIFF
--- a/src/routers/__tests__/server.test.ts
+++ b/src/routers/__tests__/server.test.ts
@@ -37,8 +37,30 @@ it("session should return a valid session", async () => {
   expect(E.isRight(session)).toBeTruthy();
 });
 
-it("test-login /test-login should always return sessionToken", async () => {
-  const result = await request.post("/test-login");
+it("test-login for LEGACY /test-login should always return sessionToken", async () => {
+  const result = await request
+    .post("/test-login")
+    .set("x-pagopa-lollipop-pub-key-hash-algo", "sha256")
+    .set(
+      "x-pagopa-lollipop-pub-key",
+      "eyJrdHkiOiJFQyIsInkiOiJuYkFGd0JLT3AvRnh4VHpITGgvbVdUL3NtSjllY0lxaElkK0dBemQxTFB3PSIsIngiOiJkdHhFZU5PK1B2RFdoVkM2ZnQyTFRLMlZvWHoxektpQmI4bkRyUy9sZGY4PSIsImNydiI6IlAtMjU2In0="
+    )
+    .set("x-pagopa-idp-id", "spid");
+
+  expect(result.status).toBe(200);
+  expect(result.body).toStrictEqual({ token: getLoginSessionToken() });
+});
+
+it("test-login for FL /test-login should always return sessionToken", async () => {
+  const result = await request
+    .post("/test-login")
+    .set("x-pagopa-lollipop-pub-key-hash-algo", "sha256")
+    .set(
+      "x-pagopa-lollipop-pub-key",
+      "eyJrdHkiOiJFQyIsInkiOiJuYkFGd0JLT3AvRnh4VHpITGgvbVdUL3NtSjllY0lxaElkK0dBemQxTFB3PSIsIngiOiJkdHhFZU5PK1B2RFdoVkM2ZnQyTFRLMlZvWHoxektpQmI4bkRyUy9sZGY4PSIsImNydiI6IlAtMjU2In0="
+    )
+    .set("x-pagopa-idp-id", "spid")
+    .set("x-pagopa-login-type", "LV");
 
   expect(result.status).toBe(200);
   expect(result.body).toStrictEqual({ token: getLoginSessionToken() });


### PR DESCRIPTION
>[!Warning]
> This PR is related to this PR the io-app: https://github.com/pagopa/io-app/pull/5996
> The demo of how it works is in the PR in io-app

## Short description
In this PR, token generation logic was added to the test login

## How to test
- Start the app using .env.local environment;
- Press the button “Login with SPID”;
- make your choice at the opt-in screen
- Here the trick to activate test form: 5 taps inside the the banner explaining how much time you have to authenticate (see attached video for how to);
- A login form should be loaded;
- Fill the form with the provided credentials (it is case sensitive);
- Press confirm button.
I the login is successful and the app flow starts, then the PR works! 
