### PR TITLE
chore: [IOBP-1140] Add onUs mocked field on PSP list

### DIFF
--- a/src/features/payments/payloads/transactions.ts
+++ b/src/features/payments/payloads/transactions.ts
@@ -29,7 +29,8 @@ export const mockAvailablePspList: ReadonlyArray<Bundle> = [
     pspBusinessName: "Banco di Sardegna",
     taxPayerFee: 456,
     primaryCiIncurredFee: 456,
-    idBundle: "B"
+    idBundle: "B",
+    onUs: true
   },
   {
     idPsp: "3",


### PR DESCRIPTION
## Short description
This PR adds a mocked field `onUs` inside of the available PSP list.

## List of changes proposed in this pull request
- Added `onUs` field to one of the PSP inside the list.
