### PR TITLE
fix: [IOBP-1167] Random IDPay test fails

### DIFF
--- a/src/routers/features/idpay/__tests__/payment.test.ts
+++ b/src/routers/features/idpay/__tests__/payment.test.ts
@@ -49,7 +49,7 @@ describe("IDPay Payment API", () => {
 
   describe("PUT putAuthPayment", () => {
     it("should return 200 with payment data", async () => {
-      const trxCode = faker.random.alphaNumeric(8, { bannedChars: "1234567" });
+      const trxCode = faker.random.alphaNumeric(8, { bannedChars: "12345678" });
 
       const response = await request.put(
         addIdPayPrefix(`/payment/qr-code/${trxCode}/authorize`)


### PR DESCRIPTION
## Short description
This PR fixes an IDPay test that fails randomly.

## List of changes proposed in this pull request
- Added the `8` character in the `trxCode` of the `PUT putAuthPayment` test.

## How to test
Tests should pass without any problem.
