### PR TITLE
[IOCOM-2086] addition of SEND banner to payload

### DIFF
--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -174,6 +174,7 @@ export const backendStatus: BackendStatus = {
     landing_banners: {
       priority_order: [
         "PUSH_NOTIFICATIONS_REMINDER",
+        "SEND_ACTIVATION_REMINDER",
         "LV_EXPIRATION_REMINDER",
         "ITW_DISCOVERY",
         "SETTINGS_DISCOVERY",


### PR DESCRIPTION
## Short description
addition of said banner's ID to the payloads object

## List of changes proposed in this pull request
- addition of banner ID


## How to test
when checking out this PR: https://github.com/pagopa/io-app/pull/6756

after enabling the banner in app, it should correctly render in the second place.