### PR TITLE
refactor: Update `landing_banners.priority_order` list

### DIFF
--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -177,7 +177,6 @@ export const backendStatus: BackendStatus = {
         "SEND_ACTIVATION_REMINDER",
         "LV_EXPIRATION_REMINDER",
         "ITW_DISCOVERY",
-        "SETTINGS_DISCOVERY",
         "INVALID_ID"
       ]
     },


### PR DESCRIPTION
## Short description
This PR removes the `SETTINGS_DISCOVERY` value from the landing banners priority order configuration list
