### PR TITLE
[IOPAE-1916] Add get serviceById v2

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -26,7 +26,7 @@ declare -a noParams=(
 declare -a noStrict=(
   "./generated/definitions/fci https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_io_sign.yaml"
   "./generated/definitions/idpay https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v11.7.1/src/domains/idpay-app/api/idpay_appio_full/openapi.appio.full.yml"
-  "./generated/definitions/services https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_services_app_backend.yaml"
+  "./generated/definitions/services https://raw.githubusercontent.com/pagopa/io-backend/refs/heads/IOPAE-1951-update-app-backend-getservice-openapi/api_services_app_backend.yaml"
 )
 
 declare -a noStrictRequestTypesRespondeDecoders=(

--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IO_BACKEND_VERSION=v16.7.4-RELEASE
+IO_BACKEND_VERSION=v16.12.1
 # need to change after merge on io-services-metadata
 IO_SERVICES_METADATA_VERSION=1.0.66
 # Session manager version
@@ -26,7 +26,7 @@ declare -a noParams=(
 declare -a noStrict=(
   "./generated/definitions/fci https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_io_sign.yaml"
   "./generated/definitions/idpay https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v11.7.1/src/domains/idpay-app/api/idpay_appio_full/openapi.appio.full.yml"
-  "./generated/definitions/services https://raw.githubusercontent.com/pagopa/io-backend/refs/heads/IOPAE-1951-update-app-backend-getservice-openapi/api_services_app_backend.yaml"
+  "./generated/definitions/services https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_services_app_backend.yaml"
 )
 
 declare -a noStrictRequestTypesRespondeDecoders=(

--- a/src/config.ts
+++ b/src/config.ts
@@ -160,9 +160,7 @@ const defaultConfig: IoDevServerConfig = {
   services: {
     response: {
       getServicesPreference: 200,
-      getServicesResponseCode: 200,
-      postServicesPreference: 200,
-      getServiceResponseCode: 200
+      postServicesPreference: 200
     },
     national: 5,
     local: 5,
@@ -204,7 +202,8 @@ const defaultConfig: IoDevServerConfig = {
         featuredInstitutionsResponseCode: 200,
         featuredServicesResponseCode: 200,
         institutionsResponseCode: 200,
-        servicesByInstitutionIdResponseCode: 200
+        servicesByInstitutionIdResponseCode: 200,
+        serviceByIdResponseCode: 200
       }
     },
     fims: {

--- a/src/features/fims/routers/relyingPartyRouter.ts
+++ b/src/features/fims/routers/relyingPartyRouter.ts
@@ -249,7 +249,7 @@ const randomServiceId = () => {
   const allServices = ServicesDB.getAllServices();
   if (allServices.length > 0) {
     const firstNationalService = allServices[0];
-    return firstNationalService.service_id;
+    return firstNationalService.id;
   }
   throw new Error(
     "RelyingPartyRouter.randomServiceId: empty service collection. It must have some values at this point"

--- a/src/features/fims/services/historyService.ts
+++ b/src/features/fims/services/historyService.ts
@@ -6,7 +6,7 @@ import { readableReportSimplified } from "@pagopa/ts-commons/lib/reporters";
 import { ulid } from "ulid";
 import { faker } from "@faker-js/faker/locale/it";
 import ServicesDB from "../../services/persistence/servicesDatabase";
-import { ServicePublic } from "../../../../generated/definitions/backend/ServicePublic";
+import { ServiceDetails } from "../../../../generated/definitions/services/ServiceDetails";
 import { Access } from "../../../../generated/definitions/fims_history/Access";
 import { FIMSConfig } from "../types/config";
 import { AccessHistoryPage } from "../../../../generated/definitions/fims_history/AccessHistoryPage";
@@ -31,11 +31,11 @@ export const generateAccessHistoryData = (
 
 export const generateAccess = (
   index: number,
-  services: ServicePublic[],
+  services: ServiceDetails[],
   relyingPartyNameForService: Map<string, Redirect>
 ): Access => {
   const serviceId =
-    services[Math.round(Math.random() * (services.length - 1))].service_id;
+    services[Math.round(Math.random() * (services.length - 1))].id;
   if (!relyingPartyNameForService.has(serviceId)) {
     relyingPartyNameForService.set(serviceId, {
       display_name: faker.company.name(),

--- a/src/features/messages/persistence/messagesPayload.ts
+++ b/src/features/messages/persistence/messagesPayload.ts
@@ -20,7 +20,7 @@ import { getRandomIntInRange } from "../../../utils/id";
 import { validatePayload } from "../../../utils/validator";
 import { thirdPartyMessagePreconditionMarkdown } from "../../../utils/variables";
 import { ThirdPartyMessagePrecondition } from "../../../../generated/definitions/backend/ThirdPartyMessagePrecondition";
-import { ServicePublic } from "../../../../generated/definitions/backend/ServicePublic";
+import { ServiceDetails } from "../../../../generated/definitions/services/ServiceDetails";
 import { FiscalCode } from "../../../../generated/definitions/backend/FiscalCode";
 import ServicesDB from "../../services/persistence/servicesDatabase";
 import PaymentsDB from "../../../persistence/payments";
@@ -96,7 +96,7 @@ export const withRemoteContent = (
 
 const serviceFromMessage = (
   message: CreatedMessageWithContent
-): E.Either<Error, Readonly<ServicePublic>> =>
+): E.Either<Error, Readonly<ServiceDetails>> =>
   pipe(message.sender_service_id, serviceId =>
     pipe(
       serviceId,
@@ -121,7 +121,7 @@ export const withPaymentData = (
     E.chain(service =>
       pipe(
         PaymentsDB.createPaymentData(
-          service.organization_fiscal_code,
+          service.organization.fiscal_code,
           invalidAfterDueDate,
           noticeNumber as PaymentNoticeNumber,
           amount as PaymentAmount
@@ -133,8 +133,8 @@ export const withPaymentData = (
                 paymentDataWithRequiredPayee
               ),
               amount as PaymentAmount,
-              service.organization_fiscal_code,
-              service.organization_name
+              service.organization.fiscal_code,
+              service.organization.name
             ),
             _ => ({
               ...message,

--- a/src/features/messages/services/messagesService.ts
+++ b/src/features/messages/services/messagesService.ts
@@ -38,7 +38,7 @@ export const getMessageCategory = (
   }
   if (
     ThirdPartyMessageWithContent.is(message) &&
-    senderService.service_id === pnServiceId
+    senderService.id === pnServiceId
   ) {
     return {
       tag: TagEnumPN.PN,
@@ -89,15 +89,15 @@ const getPublicMessages = (
             message as CreatedMessageWithContentAndEnrichedData;
 
           return {
-            service_name: senderService.service_name,
-            organization_name: senderService.organization_name,
-            organization_fiscal_code: senderService.organization_fiscal_code,
+            service_name: senderService.name,
+            organization_name: senderService.organization.name,
+            organization_fiscal_code: senderService.organization.fiscal_code,
             message_title: content.subject,
             category: getMessageCategory(message),
             is_read,
             is_archived,
             has_attachments,
-            has_precondition: senderService.service_id === pnServiceId
+            has_precondition: senderService.id === pnServiceId
           };
         }
       )
@@ -197,7 +197,7 @@ const createMessage = () =>
           subject: `Created on ${new Date().toTimeString()}`,
           markdown: `Message content that was created on ${new Date().toTimeString()}\n\nJust some more content to make sure that it has a viable length`
         },
-        sender_service_id: localService.service_id
+        sender_service_id: localService.id
       } as CreatedMessageWithContentAndAttachments)
   );
 

--- a/src/features/payments/payloads/payments.ts
+++ b/src/features/payments/payloads/payments.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker/locale/it";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
-import { ServicePublic } from "../../../../generated/definitions/backend/ServicePublic";
+import { ServiceDetails } from "../../../../generated/definitions/services/ServiceDetails";
 import { PaymentRequestsGetResponse } from "../../../../generated/definitions/pagopa/ecommerce/PaymentRequestsGetResponse";
 import { RptId } from "../../../../generated/definitions/pagopa/ecommerce/RptId";
 import ServicesDB from "../../services/persistence/servicesDatabase";
@@ -15,14 +15,14 @@ export const getPaymentRequestsGetResponse = (
     ({ service_id }) => service_id,
     ServicesDB.getService,
     O.fromNullable,
-    O.map((randomService: ServicePublic) => ({
+    O.map((randomService: ServiceDetails) => ({
       rptId,
       amount: faker.datatype.number({
         min: 1,
         max: 9999
       }) as PaymentRequestsGetResponse["amount"],
-      paFiscalCode: randomService.organization_fiscal_code,
-      paName: randomService.organization_name,
+      paFiscalCode: randomService.organization.fiscal_code,
+      paName: randomService.organization.name,
       description: faker.finance.transactionDescription(),
       dueDate: faker.date.future()
     }))

--- a/src/features/pn/payloads/messages.ts
+++ b/src/features/pn/payloads/messages.ts
@@ -136,8 +136,8 @@ const createPnMessage = (
                   createPNMessageWithContent(
                     template,
                     createdMessageWithContent,
-                    pnService.organization_fiscal_code,
-                    pnService.organization_name,
+                    pnService.organization.fiscal_code,
+                    pnService.organization.name,
                     faker.helpers.replaceSymbols("######-#-####-####-#"),
                     sharedData.sender,
                     sharedData.subject,

--- a/src/features/pn/services/services.ts
+++ b/src/features/pn/services/services.ts
@@ -1,16 +1,15 @@
-import { OrganizationFiscalCode } from "../../../../generated/definitions/backend/OrganizationFiscalCode";
-import { OrganizationName } from "../../../../generated/definitions/backend/OrganizationName";
-import { ServiceId } from "../../../../generated/definitions/backend/ServiceId";
-import { ServiceMetadata } from "../../../../generated/definitions/backend/ServiceMetadata";
-import { ServiceName } from "../../../../generated/definitions/backend/ServiceName";
-import { ServicePublic } from "../../../../generated/definitions/backend/ServicePublic";
-import { ServiceScopeEnum } from "../../../../generated/definitions/backend/ServiceScope";
-import { SpecialServiceCategoryEnum } from "../../../../generated/definitions/backend/SpecialServiceCategory";
-import { SpecialServiceMetadata } from "../../../../generated/definitions/backend/SpecialServiceMetadata";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { OrganizationFiscalCode } from "../../../../generated/definitions/services/OrganizationFiscalCode";
+import { ScopeTypeEnum } from "../../../../generated/definitions/services/ScopeType";
+import { ServiceDetails } from "../../../../generated/definitions/services/ServiceDetails";
+import { ServiceMetadata } from "../../../../generated/definitions/services/ServiceMetadata";
 import { SpecialServiceGenerator } from "../../services/persistence/services/factory";
+import { SpecialServiceCategoryEnum } from "../../../../generated/definitions/services/SpecialServiceCategory";
+import { SpecialServiceMetadata } from "../../../../generated/definitions/services/SpecialServiceMetadata";
+import { ServiceId } from "../../../../generated/definitions/services/ServiceId";
 
 export const pnServiceId = "servicePN" as ServiceId;
-export const pnOptInServiceId = "01G74SW1PSM6XY2HM5EGZHZZET" as ServiceId;
+export const pnOptInServiceId = "01G74SW1PSM6XY2HM5EGZHZZET";
 
 export const pnOptInCTA = `---
 it:
@@ -24,33 +23,37 @@ en:
 ---`;
 
 export const createPnService: SpecialServiceGenerator = (
-  createService: (serviceId: string) => ServicePublic,
-  createServiceMetadata: (scope: ServiceScopeEnum) => ServiceMetadata,
+  createService: (serviceId: string) => ServiceDetails,
+  createServiceMetadata: (scope: ScopeTypeEnum) => ServiceMetadata,
   organizationFiscalCode: OrganizationFiscalCode
-): ServicePublic => ({
+): ServiceDetails => ({
   ...createService(pnServiceId),
-  organization_name: "SEND" as OrganizationName,
-  service_name: "Notifiche digitali" as ServiceName,
-  service_metadata: {
-    ...createServiceMetadata(ServiceScopeEnum.NATIONAL),
-    category: SpecialServiceCategoryEnum.SPECIAL,
-    custom_special_flow: "pn" as SpecialServiceMetadata["custom_special_flow"]
+  organization: {
+    fiscal_code: organizationFiscalCode,
+    name: "SEND" as NonEmptyString
   },
-  organization_fiscal_code: organizationFiscalCode
+  metadata: {
+    ...createServiceMetadata(ScopeTypeEnum.NATIONAL),
+    category: SpecialServiceCategoryEnum.SPECIAL,
+    custom_special_flow: "cgn" as SpecialServiceMetadata["custom_special_flow"]
+  },
+  name: "Notifiche digitali" as NonEmptyString
 });
 
 export const createPnOptInService: SpecialServiceGenerator = (
-  createService: (serviceId: string) => ServicePublic,
-  createServiceMetadata: (scope: ServiceScopeEnum) => ServiceMetadata,
+  createService: (serviceId: string) => ServiceDetails,
+  createServiceMetadata: (scope: ScopeTypeEnum) => ServiceMetadata,
   organizationFiscalCode: OrganizationFiscalCode
-): ServicePublic => ({
+): ServiceDetails => ({
   ...createService(pnOptInServiceId),
-  organization_name: "SEND" as OrganizationName,
-  service_name: "Novità e aggiornamenti" as ServiceName,
-  service_metadata: {
-    ...createServiceMetadata(ServiceScopeEnum.NATIONAL),
+  organization: {
+    fiscal_code: organizationFiscalCode,
+    name: "SEND" as NonEmptyString
+  },
+  metadata: {
+    ...createServiceMetadata(ScopeTypeEnum.NATIONAL),
     category: SpecialServiceCategoryEnum.SPECIAL,
     custom_special_flow: "pn" as SpecialServiceMetadata["custom_special_flow"]
   },
-  organization_fiscal_code: organizationFiscalCode
+  name: "Novità e aggiornamenti" as NonEmptyString
 });

--- a/src/features/services/payloads/get-featured-services.ts
+++ b/src/features/services/payloads/get-featured-services.ts
@@ -28,10 +28,10 @@ export const getFeaturedServicesResponsePayload = (): FeaturedServices => {
   const featuredNationalServices: FeaturedService[] = pipe(
     selectedNationalServices,
     A.map(service => ({
-      id: service.service_id,
-      name: service.service_name,
-      version: service.version,
-      organization_name: service.organization_name
+      id: service.id,
+      name: service.name,
+      version: 1,
+      organization_name: service.organization.name
     }))
   );
 
@@ -41,9 +41,9 @@ export const getFeaturedServicesResponsePayload = (): FeaturedServices => {
   const featuredSpecialServices: FeaturedService[] = pipe(
     selectedSpecialServices,
     A.map(service => ({
-      id: service.service_id,
-      name: service.service_name,
-      version: service.version
+      id: service.id,
+      name: service.name,
+      version: 1
     }))
   );
 

--- a/src/features/services/payloads/get-institutions.ts
+++ b/src/features/services/payloads/get-institutions.ts
@@ -2,15 +2,15 @@ import * as A from "fp-ts/lib/Array";
 import * as O from "fp-ts/lib/Option";
 import { identity, pipe } from "fp-ts/lib/function";
 import _ from "lodash";
-import { ServiceScopeEnum } from "../../../../generated/definitions/backend/ServiceScope";
 import { Institution } from "../../../../generated/definitions/services/Institution";
 import { InstitutionsResource } from "../../../../generated/definitions/services/InstitutionsResource";
 import ServicesDB from "../persistence/servicesDatabase";
 import { InstitutionWithScope, getInstitutions } from "../utils/institutions";
+import { ScopeTypeEnum } from "../../../../generated/definitions/services/ScopeType";
 
 const filterByScope = (
   institution: InstitutionWithScope,
-  scope?: ServiceScopeEnum
+  scope?: ScopeTypeEnum
 ) => {
   if (!scope) {
     return true;
@@ -28,7 +28,7 @@ const filterBySearch = (institution: InstitutionWithScope, search?: string) => {
 export const getInstitutionsResponsePayload = (
   limit: number = 20,
   offset: number = 0,
-  scope?: ServiceScopeEnum,
+  scope?: ScopeTypeEnum,
   search?: string
 ): O.Option<InstitutionsResource> => {
   const filteredInstitutions = pipe(

--- a/src/features/services/payloads/get-services.ts
+++ b/src/features/services/payloads/get-services.ts
@@ -13,18 +13,16 @@ export const getServicesByInstitutionIdResponsePayload = (
 ): O.Option<InstitutionServicesResource> => {
   const filteredServices: ServiceMinified[] = pipe(
     ServicesDB.getAllServices(),
-    A.filterMap(
-      ({ organization_fiscal_code, service_id, service_name, version }) => {
-        if (organization_fiscal_code === institutionId) {
-          return O.some({
-            id: service_id,
-            name: service_name,
-            version
-          });
-        }
-        return O.none;
+    A.filterMap(({ id, organization, name }) => {
+      if (organization.fiscal_code === institutionId) {
+        return O.some({
+          id,
+          name,
+          version: 1
+        });
       }
-    )
+      return O.none;
+    })
   );
 
   const totalElements = filteredServices.length;

--- a/src/features/services/persistence/services/special/cdc-service.ts
+++ b/src/features/services/persistence/services/special/cdc-service.ts
@@ -1,28 +1,31 @@
-import { OrganizationFiscalCode } from "@pagopa/ts-commons/lib/strings";
-import { ServiceMetadata } from "../../../../../../generated/definitions/backend/ServiceMetadata";
-import { ServicePublic } from "../../../../../../generated/definitions/backend/ServicePublic";
-import { ServiceScopeEnum } from "../../../../../../generated/definitions/backend/ServiceScope";
-import { OrganizationName } from "../../../../../../generated/definitions/backend/OrganizationName";
-import { ServiceName } from "../../../../../../generated/definitions/backend/ServiceName";
-import { SpecialServiceCategoryEnum } from "../../../../../../generated/definitions/backend/SpecialServiceCategory";
-import { SpecialServiceMetadata } from "../../../../../../generated/definitions/backend/SpecialServiceMetadata";
-import { ServiceId } from "../../../../../../generated/definitions/backend/ServiceId";
+import {
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
 import { SpecialServiceGenerator } from "../factory";
+import { ServiceDetails } from "../../../../../../generated/definitions/services/ServiceDetails";
+import { ScopeTypeEnum } from "../../../../../../generated/definitions/services/ScopeType";
+import { ServiceMetadata } from "../../../../../../generated/definitions/services/ServiceMetadata";
+import { SpecialServiceCategoryEnum } from "../../../../../../generated/definitions/services/SpecialServiceCategory";
+import { SpecialServiceMetadata } from "../../../../../../generated/definitions/services/SpecialServiceMetadata";
+import { ServiceId } from "../../../../../../generated/definitions/services/ServiceId";
 
 const cdcServiceId = "01G2AFTME08TS0QD2P2S682CJ0" as ServiceId;
 
 export const createCdcService: SpecialServiceGenerator = (
-  createService: (serviceId: string) => ServicePublic,
-  createServiceMetadata: (scope: ServiceScopeEnum) => ServiceMetadata,
+  createService: (serviceId: string) => ServiceDetails,
+  createServiceMetadata: (scope: ScopeTypeEnum) => ServiceMetadata,
   organizationFiscalCode: OrganizationFiscalCode
-): ServicePublic => ({
+): ServiceDetails => ({
   ...createService(cdcServiceId),
-  organization_name: "Ministero beni culturali" as OrganizationName,
-  service_name: "Carta Della Cultura" as ServiceName,
-  service_metadata: {
-    ...createServiceMetadata(ServiceScopeEnum.NATIONAL),
+  organization: {
+    fiscal_code: organizationFiscalCode,
+    name: "Ministero beni culturali" as NonEmptyString
+  },
+  metadata: {
+    ...createServiceMetadata(ScopeTypeEnum.NATIONAL),
     category: SpecialServiceCategoryEnum.SPECIAL,
     custom_special_flow: "cdc" as SpecialServiceMetadata["custom_special_flow"]
   },
-  organization_fiscal_code: organizationFiscalCode
+  name: "Carta Della Cultura" as NonEmptyString
 });

--- a/src/features/services/persistence/services/special/cgn-service.ts
+++ b/src/features/services/persistence/services/special/cgn-service.ts
@@ -1,29 +1,31 @@
-import { OrganizationFiscalCode } from "@pagopa/ts-commons/lib/strings";
-import { ServiceMetadata } from "../../../../../../generated/definitions/backend/ServiceMetadata";
-import { ServicePublic } from "../../../../../../generated/definitions/backend/ServicePublic";
-import { ServiceScopeEnum } from "../../../../../../generated/definitions/backend/ServiceScope";
-import { OrganizationName } from "../../../../../../generated/definitions/backend/OrganizationName";
-import { ServiceName } from "../../../../../../generated/definitions/backend/ServiceName";
-import { SpecialServiceCategoryEnum } from "../../../../../../generated/definitions/backend/SpecialServiceCategory";
-import { SpecialServiceMetadata } from "../../../../../../generated/definitions/backend/SpecialServiceMetadata";
-import { ServiceId } from "../../../../../../generated/definitions/backend/ServiceId";
+import {
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
 import { SpecialServiceGenerator } from "../factory";
+import { ServiceDetails } from "../../../../../../generated/definitions/services/ServiceDetails";
+import { ScopeTypeEnum } from "../../../../../../generated/definitions/services/ScopeType";
+import { ServiceMetadata } from "../../../../../../generated/definitions/services/ServiceMetadata";
+import { SpecialServiceCategoryEnum } from "../../../../../../generated/definitions/services/SpecialServiceCategory";
+import { SpecialServiceMetadata } from "../../../../../../generated/definitions/services/SpecialServiceMetadata";
+import { ServiceId } from "../../../../../../generated/definitions/services/ServiceId";
 
 export const cgnServiceId = "serviceCgn" as ServiceId;
 
 export const createCgnService: SpecialServiceGenerator = (
-  createService: (serviceId: string) => ServicePublic,
-  createServiceMetadata: (scope: ServiceScopeEnum) => ServiceMetadata,
+  createService: (serviceId: string) => ServiceDetails,
+  createServiceMetadata: (scope: ScopeTypeEnum) => ServiceMetadata,
   organizationFiscalCode: OrganizationFiscalCode
-): ServicePublic => ({
+): ServiceDetails => ({
   ...createService(cgnServiceId),
-  organization_name:
-    "PCM - Dipartimento per le Politche Giovanili e il Servizio Civile Universale" as OrganizationName,
-  service_name: "Carta Giovani Nazionale" as ServiceName,
-  service_metadata: {
-    ...createServiceMetadata(ServiceScopeEnum.NATIONAL),
+  organization: {
+    fiscal_code: organizationFiscalCode,
+    name: "PCM - Dipartimento per le Politche Giovanili e il Servizio Civile Universale" as NonEmptyString
+  },
+  metadata: {
+    ...createServiceMetadata(ScopeTypeEnum.NATIONAL),
     category: SpecialServiceCategoryEnum.SPECIAL,
     custom_special_flow: "cgn" as SpecialServiceMetadata["custom_special_flow"]
   },
-  organization_fiscal_code: organizationFiscalCode
+  name: "Carta Giovani Nazionale" as NonEmptyString
 });

--- a/src/features/services/persistence/services/special/fci-service.ts
+++ b/src/features/services/persistence/services/special/fci-service.ts
@@ -1,24 +1,27 @@
-import { OrganizationFiscalCode } from "@pagopa/ts-commons/lib/strings";
-import { ServiceMetadata } from "../../../../../../generated/definitions/backend/ServiceMetadata";
-import { ServicePublic } from "../../../../../../generated/definitions/backend/ServicePublic";
-import { ServiceScopeEnum } from "../../../../../../generated/definitions/backend/ServiceScope";
-import { OrganizationName } from "../../../../../../generated/definitions/backend/OrganizationName";
-import { ServiceName } from "../../../../../../generated/definitions/backend/ServiceName";
+import {
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
 import { SpecialServiceGenerator } from "../factory";
-import { ServiceId } from "../../../../../../generated/definitions/backend/ServiceId";
+import { ServiceDetails } from "../../../../../../generated/definitions/services/ServiceDetails";
+import { ScopeTypeEnum } from "../../../../../../generated/definitions/services/ScopeType";
+import { ServiceMetadata } from "../../../../../../generated/definitions/services/ServiceMetadata";
+import { ServiceId } from "../../../../../../generated/definitions/services/ServiceId";
 
 const fciServiceId = "serviceFci" as ServiceId;
 
 export const createFciService: SpecialServiceGenerator = (
-  createService: (serviceId: string) => ServicePublic,
-  createServiceMetadata: (scope: ServiceScopeEnum) => ServiceMetadata,
+  createService: (serviceId: string) => ServiceDetails,
+  createServiceMetadata: (scope: ScopeTypeEnum) => ServiceMetadata,
   organizationFiscalCode: OrganizationFiscalCode
-): ServicePublic => ({
+): ServiceDetails => ({
   ...createService(fciServiceId),
-  organization_name: "Firma con IO" as OrganizationName,
-  service_name: "Firma con IO" as ServiceName,
-  service_metadata: {
-    ...createServiceMetadata(ServiceScopeEnum.NATIONAL)
+  organization: {
+    fiscal_code: organizationFiscalCode,
+    name: "Firma con IO" as NonEmptyString
   },
-  organization_fiscal_code: organizationFiscalCode
+  metadata: {
+    ...createServiceMetadata(ScopeTypeEnum.NATIONAL)
+  },
+  name: "Firma con IO" as NonEmptyString
 });

--- a/src/features/services/persistence/servicesDatabase.ts
+++ b/src/features/services/persistence/servicesDatabase.ts
@@ -1,13 +1,13 @@
 import { ServiceId } from "../../../../generated/definitions/backend/ServiceId";
 import { ServicePreference } from "../../../../generated/definitions/backend/ServicePreference";
-import { ServicePublic } from "../../../../generated/definitions/backend/ServicePublic";
+import { ServiceDetails } from "../../../../generated/definitions/services/ServiceDetails";
 import { isCgnActivated } from "../../../routers/features/cgn";
 import { IoDevServerConfig } from "../../../types/config";
-import { ServiceScopeEnum } from "../../../../generated/definitions/backend/ServiceScope";
 import {
   createPnOptInService,
   createPnService
 } from "../../pn/services/services";
+import { ScopeTypeEnum } from "../../../../generated/definitions/services/ScopeType";
 import { createFciService } from "./services/special/fci-service";
 import { cgnServiceId, createCgnService } from "./services/special/cgn-service";
 import ServiceFactory, { SpecialServiceGenerator } from "./services/factory";
@@ -15,16 +15,15 @@ import { createCdcService } from "./services/special/cdc-service";
 
 export type ServiceSummary = {
   service_id: ServiceId;
-  version: number;
-  scope?: ServiceScopeEnum;
+  scope: ScopeTypeEnum;
 };
 
 // eslint-disable-next-line functional/no-let
-let localServices: ServicePublic[] = [];
+let localServices: ServiceDetails[] = [];
 // eslint-disable-next-line functional/no-let
-let nationalServices: ServicePublic[] = [];
+let nationalServices: ServiceDetails[] = [];
 // eslint-disable-next-line functional/no-let
-let specialServices: ServicePublic[] = [];
+let specialServices: ServiceDetails[] = [];
 // eslint-disable-next-line functional/no-let
 let servicePreferences: Map<ServiceId, ServicePreference> = new Map<
   ServiceId,
@@ -61,16 +60,13 @@ const createServices = (config: IoDevServerConfig) => {
 
   const servicePreferenceSources = [
     ...localServices.map(localService =>
-      ServiceFactory.createServicePreferenceSource(localService.service_id)
+      ServiceFactory.createServicePreferenceSource(localService.id)
     ),
     ...nationalServices.map(nationalService =>
-      ServiceFactory.createServicePreferenceSource(nationalService.service_id)
+      ServiceFactory.createServicePreferenceSource(nationalService.id)
     ),
     ...specialServices.map(specialService =>
-      ServiceFactory.createServicePreferenceSource(
-        specialService.service_id,
-        true
-      )
+      ServiceFactory.createServicePreferenceSource(specialService.id, true)
     )
   ];
   servicePreferences = ServiceFactory.createServicePreferences(
@@ -102,22 +98,20 @@ const getPreference = (
 
 const getService = (
   serviceId: ServiceId
-): Readonly<ServicePublic> | undefined => {
-  const localService = localServices.find(
-    service => service.service_id === serviceId
-  );
+): Readonly<ServiceDetails> | undefined => {
+  const localService = localServices.find(service => service.id === serviceId);
   if (localService) {
     return localService;
   }
 
   const nationalService = nationalServices.find(
-    service => service.service_id === serviceId
+    service => service.id === serviceId
   );
   if (nationalService) {
     return nationalService;
   }
 
-  return specialServices.find(service => service.service_id === serviceId);
+  return specialServices.find(service => service.id === serviceId);
 };
 
 const getSummaries = (
@@ -129,16 +123,13 @@ const getSummaries = (
     ...(excludeSpecialServices ? [] : specialServices)
   ];
   return services.map(s => ({
-    service_id: s.service_id,
-    version: s.version,
-    scope: s.service_metadata?.scope
+    service_id: s.id,
+    scope: s.metadata.scope
   }));
 };
 
 const isSpecialService = (serviceId: ServiceId) =>
-  specialServices.some(
-    specialService => specialService.service_id === serviceId
-  );
+  specialServices.some(specialService => specialService.id === serviceId);
 
 const updatePreference = (
   serviceId: ServiceId,

--- a/src/features/services/routers/institutions.ts
+++ b/src/features/services/routers/institutions.ts
@@ -1,7 +1,7 @@
 import { sequenceT } from "fp-ts/lib/Apply";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
-import { ServiceScope } from "../../../../generated/definitions/backend/ServiceScope";
+import { ScopeType } from "../../../../generated/definitions/services/ScopeType";
 import { ioDevServerConfig } from "../../../config";
 import { addHandler } from "../../../payloads/response";
 import { getFeaturedInstitutionsResponsePayload } from "../payloads/get-featured-institutions";
@@ -35,7 +35,7 @@ addHandler(serviceRouter, "get", addApiV2Prefix("/institutions"), (req, res) =>
             O.of(
               pipe(
                 req.query.scope,
-                ServiceScope.decode,
+                ScopeType.decode,
                 O.fromEither,
                 O.toUndefined
               )

--- a/src/features/services/routers/services.ts
+++ b/src/features/services/routers/services.ts
@@ -9,6 +9,29 @@ import { addApiV2Prefix, serviceRouter } from "./router";
 
 const serviceConfig = ioDevServerConfig.features.service;
 
+// Retrieve featured services
+addHandler(
+  serviceRouter,
+  "get",
+  addApiV2Prefix("/services/featured"),
+  (_, res) =>
+    pipe(
+      serviceConfig.response.featuredServicesResponseCode,
+      O.fromPredicate(statusCode => statusCode !== 200),
+      O.fold(
+        () =>
+          pipe(
+            O.of(getFeaturedServicesResponsePayload()),
+            O.fold(
+              () => res.status(500),
+              featuredServices => res.status(200).json(featuredServices)
+            )
+          ),
+        statusCode => res.sendStatus(statusCode)
+      )
+    )
+);
+
 // Retrive service by id
 addHandler(
   serviceRouter,
@@ -29,29 +52,6 @@ addHandler(
             O.fold(
               () => res.sendStatus(404),
               service => res.status(200).json(service)
-            )
-          ),
-        statusCode => res.sendStatus(statusCode)
-      )
-    )
-);
-
-// Retrieve featured services
-addHandler(
-  serviceRouter,
-  "get",
-  addApiV2Prefix("/services/featured"),
-  (_, res) =>
-    pipe(
-      serviceConfig.response.featuredServicesResponseCode,
-      O.fromPredicate(statusCode => statusCode !== 200),
-      O.fold(
-        () =>
-          pipe(
-            O.of(getFeaturedServicesResponsePayload()),
-            O.fold(
-              () => res.status(404),
-              featuredServices => res.status(200).json(featuredServices)
             )
           ),
         statusCode => res.sendStatus(statusCode)

--- a/src/features/services/routers/services.ts
+++ b/src/features/services/routers/services.ts
@@ -1,11 +1,40 @@
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
+import { ServiceId } from "../../../../generated/definitions/services/ServiceId";
 import { ioDevServerConfig } from "../../../config";
 import { addHandler } from "../../../payloads/response";
 import { getFeaturedServicesResponsePayload } from "../payloads/get-featured-services";
+import ServicesDB from "../persistence/servicesDatabase";
 import { addApiV2Prefix, serviceRouter } from "./router";
 
 const serviceConfig = ioDevServerConfig.features.service;
+
+// Retrive service by id
+addHandler(
+  serviceRouter,
+  "get",
+  addApiV2Prefix("/services/:serviceId"),
+  (req, res) =>
+    pipe(
+      serviceConfig.response.serviceByIdResponseCode,
+      O.fromPredicate(statusCode => statusCode !== 200),
+      O.fold(
+        () =>
+          pipe(
+            req.params.serviceId as ServiceId,
+            O.fromNullable,
+            O.chain(serviceId =>
+              pipe(serviceId, ServicesDB.getService, O.fromNullable)
+            ),
+            O.fold(
+              () => res.sendStatus(404),
+              service => res.status(200).json(service)
+            )
+          ),
+        statusCode => res.sendStatus(statusCode)
+      )
+    )
+);
 
 // Retrieve featured services
 addHandler(

--- a/src/features/services/types/configuration.ts
+++ b/src/features/services/types/configuration.ts
@@ -16,7 +16,9 @@ export const ServiceConfiguration = t.type({
     // 200 success with payload
     institutionsResponseCode: HttpResponseCode,
     // 200 success with payload
-    servicesByInstitutionIdResponseCode: HttpResponseCode
+    servicesByInstitutionIdResponseCode: HttpResponseCode,
+    // 200 success with payload
+    serviceByIdResponseCode: HttpResponseCode
   })
 });
 

--- a/src/features/services/utils/institutions.ts
+++ b/src/features/services/utils/institutions.ts
@@ -1,24 +1,24 @@
 import * as A from "fp-ts/lib/Array";
 import { pipe } from "fp-ts/lib/function";
-import { ServicePublic } from "../../../../generated/definitions/backend/ServicePublic";
-import { ServiceScopeEnum } from "../../../../generated/definitions/backend/ServiceScope";
+import { ServiceDetails } from "../../../../generated/definitions/services/ServiceDetails";
+import { ScopeTypeEnum } from "../../../../generated/definitions/services/ScopeType";
 import { Institution } from "../../../../generated/definitions/services/Institution";
 
-export type InstitutionWithScope = Institution & { scope?: ServiceScopeEnum };
+export type InstitutionWithScope = Institution & { scope?: ScopeTypeEnum };
 
 export const getInstitutions = (
-  services: ServicePublic[]
+  services: ServiceDetails[]
 ): InstitutionWithScope[] =>
   pipe(
     services,
     A.uniq({
       equals: (x, y) =>
-        x.organization_fiscal_code === y.organization_fiscal_code
+        x.organization.fiscal_code === y.organization.fiscal_code
     }),
     A.map(service => ({
-      id: service.organization_fiscal_code,
-      name: service.organization_name,
-      fiscal_code: service.organization_fiscal_code,
-      scope: service.service_metadata?.scope
+      id: service.organization.fiscal_code,
+      name: service.organization.name,
+      fiscal_code: service.organization.fiscal_code,
+      scope: service.metadata.scope
     }))
   );

--- a/src/payloads/features/idpay/get-initiative-beneficiary-detail.ts
+++ b/src/payloads/features/idpay/get-initiative-beneficiary-detail.ts
@@ -40,7 +40,7 @@ const generateRandomInitiativeDetailDTO = (
     tcLink: faker.internet.url(),
     logoURL: initiative.logoURL,
     updateDate: faker.date.recent(1),
-    serviceId: faker.helpers.arrayElement(serviceSummaries)?.service_id
+    serviceId: faker.helpers.arrayElement(serviceSummaries).service_id
   };
 };
 

--- a/src/payloads/payload.ts
+++ b/src/payloads/payload.ts
@@ -8,7 +8,7 @@ import { PaymentActivationsGetResponse } from "../../generated/definitions/backe
 import { PaymentActivationsPostResponse } from "../../generated/definitions/backend/PaymentActivationsPostResponse";
 import { PaymentNoticeNumber } from "../../generated/definitions/backend/PaymentNoticeNumber";
 import { PaymentRequestsGetResponse } from "../../generated/definitions/backend/PaymentRequestsGetResponse";
-import { ServicePublic } from "../../generated/definitions/backend/ServicePublic";
+import { ServiceDetails } from "../../generated/definitions/services/ServiceDetails";
 import { SpezzoneStrutturatoCausaleVersamento } from "../../generated/definitions/backend/SpezzoneStrutturatoCausaleVersamento";
 import { Payment } from "../../generated/definitions/pagopa/walletv2/Payment";
 import { PaymentResponse } from "../../generated/definitions/pagopa/walletv2/PaymentResponse";
@@ -258,7 +258,7 @@ export const transactionIdResponseSecond = {
 };
 
 export const getPaymentRequestsGetResponse = (
-  senderService: ServicePublic
+  senderService: ServiceDetails
 ): PaymentRequestsGetResponse => ({
   importoSingoloVersamento: getRandomValue(
     ioDevServerConfig.wallet.payment
@@ -276,8 +276,8 @@ export const getPaymentRequestsGetResponse = (
     faker.finance.iban() as PaymentRequestsGetResponse["ibanAccredito"],
   causaleVersamento: faker.finance.transactionDescription(),
   enteBeneficiario: {
-    identificativoUnivocoBeneficiario: senderService.organization_fiscal_code,
-    denominazioneBeneficiario: senderService.organization_name
+    identificativoUnivocoBeneficiario: senderService.organization.fiscal_code,
+    denominazioneBeneficiario: senderService.organization.name
   },
   spezzoniCausaleVersamento: [
     {

--- a/src/routers/__tests__/service.test.ts
+++ b/src/routers/__tests__/service.test.ts
@@ -1,9 +1,5 @@
-import * as E from "fp-ts/lib/Either";
 import supertest from "supertest";
-import { PaginatedServiceTupleCollection } from "../../../generated/definitions/backend/PaginatedServiceTupleCollection";
-import { ServicePublic } from "../../../generated/definitions/backend/ServicePublic";
 import { ioDevServerConfig, staticContentRootPath } from "../../config";
-import { basePath } from "../../payloads/response";
 import app from "../../server";
 import ServicesDB from "../../features/services/persistence/servicesDatabase";
 
@@ -12,33 +8,6 @@ const request = supertest(app);
 beforeAll(() => ServicesDB.createServices(ioDevServerConfig));
 
 afterAll(() => ServicesDB.deleteServices());
-
-it("services should return a valid services list", async () => {
-  const response = await request.get(`${basePath}/services`);
-  expect(response.status).toBe(200);
-  const list = PaginatedServiceTupleCollection.decode(response.body);
-  expect(E.isRight(list)).toBeTruthy();
-  if (E.isRight(list)) {
-    const servicesSummaries = ServicesDB.getSummaries();
-    const paginatedServicesSummaries = {
-      items: servicesSummaries,
-      page_size: servicesSummaries.length
-    };
-    expect(list.right).toEqual(paginatedServicesSummaries);
-  }
-});
-
-it("services should return a valid service with content", async () => {
-  const servicesSummaries = ServicesDB.getSummaries();
-  const serviceId = servicesSummaries[0].service_id;
-  const response = await request.get(`${basePath}/services/${serviceId}`);
-  expect(response.status).toBe(200);
-  const service = ServicePublic.decode(response.body);
-  expect(E.isRight(service)).toBeTruthy();
-  if (E.isRight(service)) {
-    expect(service.right.service_id).toBe(serviceId);
-  }
-});
 
 it("static_contents should return a valid service logo", async () => {
   const response = await request.get(

--- a/src/routers/features/idpay/__tests__/wallet.test.ts
+++ b/src/routers/features/idpay/__tests__/wallet.test.ts
@@ -10,6 +10,8 @@ import {
 import app from "../../../../server";
 import { getWalletV2 } from "../../../walletsV2";
 import { addIdPayPrefix } from "../router";
+import ServicesDB from "../../../../features/services/persistence/servicesDatabase";
+import { ioDevServerConfig } from "../../../../config";
 
 const request = supertest(app);
 
@@ -17,6 +19,10 @@ const initiatives = Object.values(idPayInitiatives);
 
 // eslint-disable-next-line max-lines-per-function
 describe("IDPay Wallet API", () => {
+  beforeAll(() => {
+    ServicesDB.createServices(ioDevServerConfig);
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/src/routers/payment.ts
+++ b/src/routers/payment.ts
@@ -10,7 +10,7 @@ import { PaymentActivationsPostRequest } from "../../generated/definitions/backe
 import { PaymentActivationsPostResponse } from "../../generated/definitions/backend/PaymentActivationsPostResponse";
 import { Detail_v2Enum } from "../../generated/definitions/backend/PaymentProblemJson";
 import { PaymentRequestsGetResponse } from "../../generated/definitions/backend/PaymentRequestsGetResponse";
-import { ServicePublic } from "../../generated/definitions/backend/ServicePublic";
+import { ServiceDetails } from "../../generated/definitions/services/ServiceDetails";
 import { PaymentResponse } from "../../generated/definitions/pagopa/walletv2/PaymentResponse";
 import { ioDevServerConfig } from "../config";
 import { getProblemJson } from "../payloads/error";
@@ -103,7 +103,7 @@ addHandler(
                       "Unable to find auto-referenced service"
                     )
                   ),
-              (randomService: ServicePublic) =>
+              (randomService: ServiceDetails) =>
                 pipe(
                   ioDevServerConfig.wallet.verificaError,
                   O.fromNullable,

--- a/src/routers/services_metadata.ts
+++ b/src/routers/services_metadata.ts
@@ -6,7 +6,6 @@ import { Router } from "express";
 import * as E from "fp-ts/lib/Either";
 import * as B from "fp-ts/lib/boolean";
 import { pipe } from "fp-ts/lib/function";
-import { ServiceId } from "../../generated/definitions/backend/ServiceId";
 import { SpidIdps } from "../../generated/definitions/content/SpidIdps";
 import { VersionInfo } from "../../generated/definitions/content/VersionInfo";
 import { Zendesk } from "../../generated/definitions/content/Zendesk";
@@ -28,7 +27,6 @@ import {
 } from "../utils/file";
 import { serverUrl } from "../utils/server";
 import { validatePayload } from "../utils/validator";
-import ServicesDB from "../features/services/persistence/servicesDatabase";
 import { cgnServiceId } from "../features/services/persistence/services/special/cgn-service";
 
 export const servicesMetadataRouter = Router();
@@ -57,25 +55,6 @@ export const initializeServiceLogoMap = () => {
     `${serviceLogoBaseRelativePathGenerator()}specialServices/service_cgn.png`
   );
 };
-
-/**
- * @deprecated the app should not use this API. It should consume metadata contained in the service detail
- */
-addHandler(
-  servicesMetadataRouter,
-  "get",
-  addRoutePrefix(`/services/:service_id`),
-  (req, res) => {
-    const serviceId = req.params.service_id.split(".")[0] as ServiceId;
-    const service = ServicesDB.getService(serviceId);
-    if (service === undefined || service.service_metadata === undefined) {
-      res.sendStatus(404);
-      return;
-    }
-    const serviceMetadata = service.service_metadata;
-    res.json(serviceMetadata);
-  }
-);
 
 // backend service status
 addHandler(

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -101,10 +101,6 @@ export const ServicesConfig = t.intersection([
   t.interface({
     // configure some API response error code
     response: t.interface({
-      // 200 success with payload
-      getServicesResponseCode: HttpResponseCode,
-      // 200 success with payload
-      getServiceResponseCode: HttpResponseCode,
       // 200 success
       postServicesPreference: HttpResponseCode,
       // 200 success with payload

--- a/src/utils/payment.ts
+++ b/src/utils/payment.ts
@@ -7,7 +7,7 @@ import {
 } from "../../generated/definitions/backend/PaymentProblemJson";
 import { RptId } from "../../generated/definitions/backend/RptId";
 import { NotificationPaymentInfo } from "../features/pn/types/notificationPaymentInfo";
-import { ServicePublic } from "../../generated/definitions/backend/ServicePublic";
+import { ServiceDetails } from "../../generated/definitions/services/ServiceDetails";
 import { PaymentData } from "../../generated/definitions/backend/PaymentData";
 
 export const enum CreditCardBrandEnum {
@@ -73,9 +73,9 @@ export const rptIdFromNotificationPaymentInfo = (
   `${notificationPaymentInfo.creditorTaxId}${notificationPaymentInfo.noticeCode}`;
 
 export const rptIdFromServiceAndPaymentData = (
-  service: ServicePublic,
+  service: ServiceDetails,
   paymentData: PaymentData
-) => `${service.organization_fiscal_code}${paymentData.notice_number}`;
+) => `${service.organization.fiscal_code}${paymentData.notice_number}`;
 
 export const isPaid = (paymentProblemJSON: PaymentProblemJson) =>
   pipe(


### PR DESCRIPTION
This PR depends on https://github.com/pagopa/io-backend/pull/1205 and https://github.com/pagopa/io-dev-api-server/pull/476

## Short description
This PR introduces the new GET `getServiceById` to retrieve service details, while removing the old endpoint.

## How to test
You can test this PR using a REST client
