### PR TITLE
chore: [IOBP-1577] add `webViewPaymentFlow` feature flag

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v16.12.1
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=IOBP-1577-payment-flow-webview-feature-flag
+IO_SERVICES_METADATA_VERSION=1.0.68
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.4.0
 

--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v16.12.1
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.67
+IO_SERVICES_METADATA_VERSION=IOBP-1577-payment-flow-webview-feature-flag
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.4.0
 

--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -162,6 +162,12 @@ export const backendStatus: BackendStatus = {
               "Don't worry: you will have to select it in the next steps."
           }
         }
+      },
+      webViewPaymentFlow: {
+        min_app_version: {
+          ios: "2.65.0.0",
+          android: "2.65.0.0"
+        }
       }
     },
     fastLogin: {


### PR DESCRIPTION
## ⚠️ This PR depends on https://github.com/pagopa/io-services-metadata/pull/960

## Short description
This PR adds the `webViewPaymentFlow` remote feature flag to mock the enabled version.

## List of changes proposed in this pull request
- Changed the `IO_SERVICES_METADATA_VERSION` value so that ASAP the dependent PR will be merged, must be updated with the correct version;

