### PR TITLE
revert: [IOBP-1323] CGN Contacts support property mock

### DIFF
--- a/src/payloads/features/cgn/merchants.ts
+++ b/src/payloads/features/cgn/merchants.ts
@@ -19,9 +19,7 @@ import {
 } from "../../../../generated/definitions/cgn/merchants/ProductCategory";
 import { getRandomValue } from "../../../utils/random";
 import { serverUrl } from "../../../utils/server";
-import { SupportTypeEnum } from "../../../../generated/definitions/cgn/merchants/SupportType";
-import { getRandomEnumValue } from "../../utils/random";
-import { ALL_NATIONAL_ADDRESSES_TEXT, getSupportValueFromType } from "./utils";
+import { ALL_NATIONAL_ADDRESSES_TEXT } from "./utils";
 
 const availableCategories: ReadonlyArray<ProductCategory> = [
   ProductCategoryEnum.cultureAndEntertainment,
@@ -192,7 +190,6 @@ const generateDiscount = (
 export const generateMerchantDetail = (
   merchant: OnlineMerchant | OfflineMerchant
 ): Merchant => {
-  const supportType = getRandomEnumValue(SupportTypeEnum);
   if (OnlineMerchant.is(merchant)) {
     return {
       id: merchant.id,
@@ -207,9 +204,7 @@ export const generateMerchantDetail = (
       ).map<Discount>(_ =>
         generateDiscount(merchant.productCategories, merchant.discountCodeType)
       ),
-      allNationalAddresses: true,
-      supportType,
-      supportValue: getSupportValueFromType(supportType)
+      allNationalAddresses: true
     };
   } else {
     const addresses = range(0, faker.datatype.number({ min: 0, max: 3 }));
@@ -229,9 +224,7 @@ export const generateMerchantDetail = (
         faker.datatype.number({ min: 1, max: 4 })
       ).map<Discount>(_ => generateDiscount(merchant.productCategories)),
       websiteUrl: faker.internet.url() as NonEmptyString,
-      allNationalAddresses: addresses.length === 1,
-      supportType,
-      supportValue: getSupportValueFromType(supportType)
+      allNationalAddresses: addresses.length === 1
     };
   }
 };

--- a/src/payloads/features/cgn/utils.ts
+++ b/src/payloads/features/cgn/utils.ts
@@ -1,17 +1,2 @@
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { faker } from "@faker-js/faker/locale/it";
-import { SupportTypeEnum } from "../../../../generated/definitions/cgn/merchants/SupportType";
-
 export const ALL_NATIONAL_ADDRESSES_TEXT =
   "Tutti i punti vendita sul territorio nazionale";
-
-export const getSupportValueFromType = (supportType: SupportTypeEnum) => {
-  switch (supportType) {
-    case SupportTypeEnum.EMAILADDRESS:
-      return faker.internet.email() as NonEmptyString;
-    case SupportTypeEnum.PHONENUMBER:
-      return faker.phone.number("+39 #########") as NonEmptyString;
-    case SupportTypeEnum.WEBSITE:
-      return faker.internet.url() as NonEmptyString;
-  }
-};


### PR DESCRIPTION
## Short description
This PR reverts the contact support property mock that isn't used anymore.

## List of changes proposed in this pull request
- Removed the `supportType` and `supportValue` property mock generator.