### PR TITLE
chore: [IOBP-1727] Add CdC FIMS mock config

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v16.12.1
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=IOBP-1727-add-cdc-fims-configurations
+IO_SERVICES_METADATA_VERSION=1.0.69
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.4.0
 

--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v16.12.1
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.68
+IO_SERVICES_METADATA_VERSION=IOBP-1727-add-cdc-fims-configurations
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.4.0
 

--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -66,6 +66,11 @@ export const backendStatus: BackendStatus = {
           organization_fiscal_code: "97532760580",
           organization_name: "Ministero delle infrastrutture e dei trasporti",
           service_name: "Motorizzazione Civile - Le mie patenti"
+        },
+        {
+          configuration_id: "cdc-onboarding",
+          service_id: "01JV4M365CHAZN5C0FDR62DCVD",
+          service_name: "Carta della Cultura - Onboarding"
         }
       ]
     },
@@ -79,6 +84,9 @@ export const backendStatus: BackendStatus = {
       min_app_version: {
         android: "2.68.0.0",
         ios: "2.68.0.0"
+      },
+      cta_onboarding_config: {
+        url: "https://api-app.io.pagopa.it/api/cdc/v1/fauth"
       }
     },
     barcodesScanner: {

--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -86,7 +86,8 @@ export const backendStatus: BackendStatus = {
         ios: "2.68.0.0"
       },
       cta_onboarding_config: {
-        url: "https://api-app.io.pagopa.it/api/cdc/v1/fauth"
+        url: "https://api-app.io.pagopa.it/api/cdc/v1/fauth",
+        includeDeviceId: true
       }
     },
     barcodesScanner: {


### PR DESCRIPTION
## ⚠️ This PR depends on https://github.com/pagopa/io-services-metadata/pull/978

## Short description
This PR introduces updates to the API model generation and backend configuration payloads to support new FIMS service configurations and CdC onboarding remote url.

## List of changes proposed in this pull request
* [`src/payloads/backend.ts`](diffhunk://#diff-7ff7240bd72d8e1a05d545469bd2840db7ce9a138c2172e29389c43a39f9a0c1R69-R73): Added a new service configuration for "Carta della Cultura - Onboarding" with its associated `configuration_id`, `service_id`, and `service_name`.
* [`src/payloads/backend.ts`](diffhunk://#diff-7ff7240bd72d8e1a05d545469bd2840db7ce9a138c2172e29389c43a39f9a0c1R87-R89): Introduced a new `cta_onboarding_config` object with a URL for the CDC onboarding API endpoint.
