### PR TITLE
fix: [IOCOM-2302] Fix bad conversion for dueDate in paymentData

### DIFF
--- a/src/persistence/payments.ts
+++ b/src/persistence/payments.ts
@@ -74,7 +74,7 @@ const createProcessablePayment = (
   amount: PaymentAmount,
   organizationFiscalCode: OrganizationFiscalCode,
   organizationName: OrganizationName,
-  dueDate: Date = faker.date.soon(),
+  nativeDueDate: Date = faker.date.soon(),
   organizationUnitName: NonEmptyString = faker.random.alphaNumeric(
     3
   ) as NonEmptyString,
@@ -100,7 +100,7 @@ const createProcessablePayment = (
           spezzoneCausaleVersamento: paymentShortReason
         }
       ],
-      dueDate
+      dueDate: nativeDueDate.toISOString().split("T")[0]
     } as PaymentRequestsGetResponse,
     processablePayment,
     processablePayment => addOrUpdatePaymentStatus(rptId, processablePayment)


### PR DESCRIPTION
## Short description
This PR fixes the dueDate format conversion.

## List of changes proposed in this pull request
- dueDate was being stored as a Date into paymentData but its type was a PatternString(YYYY-MM-DD)

