### PR TITLE
wip: [IOPID-3154] Point to the new `io-services-metadata` specs to include the new `loginUrl` field inside `loginConfig`

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v16.17.0
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.71
+IO_SERVICES_METADATA_VERSION=IOPID-3153
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.4.0
 


### PR DESCRIPTION
> [!warning]
> This PR depends on https://github.com/pagopa/io-services-metadata/pull/996

## Short description
Point to the new `io-services-metadata` specs to include the new `loginUrl` field inside `loginConfig`.

## List of changes proposed in this pull request
- Point to updated `io-services-metadata` specs with `loginUrl` support.
- **Important**: Do not add `loginUrl` to `backend.ts`; during development, fallback to .env remains in use.

## How to test
- Run `yarn generate`
- Run `yarn tsc:noemit`
- Confirm there are no type errors