### PR TITLE
feat: [IOBP-1887] Generate IDPay services to activate message notifications in IO app

### DIFF
--- a/src/features/services/persistence/servicesDatabase.ts
+++ b/src/features/services/persistence/servicesDatabase.ts
@@ -2,6 +2,7 @@ import { ServiceId } from "../../../../generated/definitions/backend/ServiceId";
 import { ServicePreference } from "../../../../generated/definitions/backend/ServicePreference";
 import { ScopeTypeEnum } from "../../../../generated/definitions/services/ScopeType";
 import { ServiceDetails } from "../../../../generated/definitions/services/ServiceDetails";
+import { generateIDPayServices } from "../../../payloads/features/idpay/generateIDPayServices";
 import { isCgnActivated } from "../../../routers/features/cgn";
 import { IoDevServerConfig } from "../../../types/config";
 import {
@@ -43,7 +44,8 @@ const createServices = (config: IoDevServerConfig) => {
       nationalServiceCount,
       localServiceCount
     ),
-    createPnOptInService()
+    createPnOptInService(),
+    ...generateIDPayServices()
   ];
 
   const specialServiceGenerators: Array<[boolean, SpecialServiceGenerator]> = [

--- a/src/payloads/features/idpay/generateIDPayServices.ts
+++ b/src/payloads/features/idpay/generateIDPayServices.ts
@@ -1,0 +1,24 @@
+import {
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
+import { ScopeTypeEnum } from "../../../../generated/definitions/services/ScopeType";
+import { ServiceDetails } from "../../../../generated/definitions/services/ServiceDetails";
+import {
+  createServiceFromFactory,
+  createServiceMetadataFromFactory
+} from "../../../features/services/persistence/services/factory";
+import { IDPayServiceID } from "./types";
+
+export const generateIDPayServices = (): ServiceDetails[] =>
+  Object.values(IDPayServiceID).map(serviceId => ({
+    ...createServiceFromFactory(`TESTSRV${serviceId}` as string),
+    organization: {
+      fiscal_code: "00000009898" as OrganizationFiscalCode,
+      name: `TESTSRV${serviceId}` as NonEmptyString
+    },
+    metadata: {
+      ...createServiceMetadataFromFactory(ScopeTypeEnum.NATIONAL)
+    },
+    name: `TESTSRV${serviceId}` as NonEmptyString
+  }));


### PR DESCRIPTION
## Short description
This pull request introduces functionality to generate services for IDPay and integrates them into the existing service creation pipeline

## List of changes proposed in this pull request
- Added `generateIDPayServices` to the imports and updated the `createServices` function to include IDPay services in the service array
- 
## How to test
Ensure that now from the IO app is possible to enable messages for every IDPay initiatives