### PR TITLE
feat: [IOCOM-2574] Non-blocking check for `isTest` parameter

### DIFF
--- a/src/features/messages/services/ioSendService.ts
+++ b/src/features/messages/services/ioSendService.ts
@@ -10,6 +10,23 @@ export const mandateIdOrUndefinedFromQuery = (
   return typeof requestMandateId === "string" ? requestMandateId : undefined;
 };
 
+export const isTestOrUndefinedFromQuery = (
+  query: ParsedQs
+): boolean | undefined => {
+  const { isTest } = query;
+  if (typeof isTest !== "string") {
+    return undefined;
+  }
+  switch (isTest.toLowerCase()) {
+    case "true":
+      return true;
+    case "false":
+      return false;
+    default:
+      return undefined;
+  }
+};
+
 export const generateRequestHeaders = (
   headers: IncomingHttpHeaders,
   contentType: string = "application/json"

--- a/src/features/pn/middlewares/authenticationMiddleware.ts
+++ b/src/features/pn/middlewares/authenticationMiddleware.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { APIKey } from "../models/APIKey";
 import { getProblemJson } from "../../../payloads/error";
 import { ioDevServerConfig } from "../../../config";
-import { logExpressWarning } from "../../../utils/logging";
+import { logExpressResponseWarning } from "../../../utils/logging";
 
 // Middleware have to be used like this (instead of directly giving the middleware to the router via use)
 // because supertest (when testing) calls every middleware upon test initialization, even if it not in a
@@ -20,7 +20,7 @@ export const authenticationMiddleware =
           "Unauthorized API Access",
           `Missing or invalid value for header 'x-api-key'`
         );
-        logExpressWarning(401, problemJson);
+        logExpressResponseWarning(401, problemJson);
         response.status(401).json(problemJson);
         return;
       }

--- a/src/features/pn/middlewares/initializationMiddleware.ts
+++ b/src/features/pn/middlewares/initializationMiddleware.ts
@@ -13,7 +13,7 @@ import { PaymentsDatabase } from "../../../persistence/payments";
 import { AARRepository } from "../repositories/aarRepository";
 import { PrevalidatedUrisRepository } from "../repositories/prevalidatedUrisRepository";
 import { getProblemJson } from "../../../payloads/error";
-import { logExpressWarning } from "../../../utils/logging";
+import { logExpressResponseWarning } from "../../../utils/logging";
 import { MandateRepository } from "../repositories/mandateRepository";
 
 // Middleware have to be used like this (instead of directly giving the middleware to the router via use)
@@ -29,7 +29,7 @@ export const initializationMiddleware =
         "SEND repositories initialization failed",
         `An error occourred while trying to initialize repositories for SEND (${initializationEither.left})`
       );
-      logExpressWarning(500, problemJson);
+      logExpressResponseWarning(500, problemJson);
       response.status(500).json();
       return;
     }

--- a/src/features/pn/routers/aarRouter.ts
+++ b/src/features/pn/routers/aarRouter.ts
@@ -8,7 +8,7 @@ import { ioDevServerConfig } from "../../../config";
 import { getProblemJson } from "../../../payloads/error";
 import { handleLeftEitherIfNeeded } from "../../../utils/error";
 import { notificationOrMandateDataFromQRCode } from "../services/aarService";
-import { logExpressWarning } from "../../../utils/logging";
+import { logExpressResponseWarning } from "../../../utils/logging";
 
 const checkQRCodePath = "/delivery/notifications/received/check-qr-code";
 
@@ -39,7 +39,7 @@ addHandler(
           "Bad body value",
           `Request body does not contain a valid JSON with the 'qrcode' property (${inputQRCodeContent})`
         );
-        logExpressWarning(400, problemJson);
+        logExpressResponseWarning(400, problemJson);
         res.status(400).json(problemJson);
         return;
       }

--- a/src/features/pn/routers/notificationsRouter.ts
+++ b/src/features/pn/routers/notificationsRouter.ts
@@ -15,7 +15,7 @@ import {
 import { handleLeftEitherIfNeeded } from "../../../utils/error";
 import { ioDevServerConfig } from "../../../config";
 import { getProblemJson } from "../../../payloads/error";
-import { logExpressWarning } from "../../../utils/logging";
+import { logExpressResponseWarning } from "../../../utils/logging";
 
 const notificationDisclaimerPath =
   "/ext-registry-private/io/v1/notification-disclaimer/:iun";
@@ -91,7 +91,7 @@ addHandler(
           "User mismatch",
           `The specified notification does not belong to the user that is requesting it (${notification.iun}) (${taxIdEither.right})`
         );
-        logExpressWarning(400, problemJson);
+        logExpressResponseWarning(400, problemJson);
         res.status(400).json(problemJson);
         return;
       }

--- a/src/features/pn/routers/serviceRouter.ts
+++ b/src/features/pn/routers/serviceRouter.ts
@@ -7,7 +7,7 @@ import { addHandler } from "../../../payloads/response";
 import { addApiV1Prefix } from "../../../utils/strings";
 import ServicesDB from "../../services/persistence/servicesDatabase";
 import { sendServiceId } from "../services/dataService";
-import { logExpressWarning } from "../../../utils/logging";
+import { logExpressResponseWarning } from "../../../utils/logging";
 import { getProblemJson } from "../../../payloads/error";
 
 export const sendServiceRouter = Router();
@@ -24,7 +24,7 @@ addHandler(sendServiceRouter, "post", addPrefix("/activation"), (req, res) => {
         maybeActivation.left
       )})`
     );
-    logExpressWarning(400, problemJson);
+    logExpressResponseWarning(400, problemJson);
     res.status(400).json(problemJson);
     return;
   }
@@ -35,7 +35,7 @@ addHandler(sendServiceRouter, "post", addPrefix("/activation"), (req, res) => {
       "sendServiceId not found",
       `Unable to retrieve Service preferences for sendServiceId (${sendServiceId})`
     );
-    logExpressWarning(500, problemJson);
+    logExpressResponseWarning(500, problemJson);
     res.status(500).json(problemJson);
     return;
   }
@@ -55,7 +55,7 @@ addHandler(sendServiceRouter, "post", addPrefix("/activation"), (req, res) => {
       "Preferences not updated",
       `Unable to update service preference for sendServiceId (${sendServiceId})`
     );
-    logExpressWarning(500, problemJson);
+    logExpressResponseWarning(500, problemJson);
     res.status(500).json(problemJson);
     return;
   }

--- a/src/features/pn/services/commonService.ts
+++ b/src/features/pn/services/commonService.ts
@@ -4,7 +4,7 @@ import { Either, isLeft, left, right } from "fp-ts/lib/Either";
 import { ExpressFailure } from "../../../utils/expressDTO";
 import { getProblemJson } from "../../../payloads/error";
 import { SendConfig } from "../types/sendConfig";
-import { logExpressWarning } from "../../../utils/logging";
+import { logWarning } from "../../../utils/logging";
 import { checkAndValidateLollipopHeaders } from "./lollipopService";
 
 export const checkAndValidateLollipopAndTaxId = (
@@ -88,13 +88,8 @@ export const checkSourceHeaderNonBlocking = (
     (sourceHeader.toUpperCase() !== "QRCODE" &&
       sourceHeader.toUpperCase() !== "DEFAULT")
   ) {
-    logExpressWarning(
-      400,
-      getProblemJson(
-        400,
-        "Non-Blocking bad value x-pagopa-pn-io-src",
-        `Bad value for header 'x-pagopa-pn-io-src'. While this is just a warning and not a blocking error, make sure that your final API provide such header. Allowed values: DEFAULT | QRCODE (${sourceHeader})`
-      )
+    logWarning(
+      `\n  Bad value for header 'x-pagopa-pn-io-src'. While this is just a warning and not a blocking error, make sure that your final API provide such header. Allowed values: DEFAULT | QRCODE (${sourceHeader})\n`
     );
   }
 };

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
 import { Either, isLeft, Left } from "fp-ts/lib/Either";
-import { logExpressWarning } from "./logging";
+import { logExpressResponseWarning } from "./logging";
 import { ExpressFailure } from "./expressDTO";
 
 export const handleLeftEitherIfNeeded = (
@@ -10,7 +10,7 @@ export const handleLeftEitherIfNeeded = (
   if (isLeft(inputEither)) {
     const httpStatusCode = inputEither.left.httpStatusCode;
     const problemJson = inputEither.left.reason;
-    logExpressWarning(httpStatusCode, problemJson);
+    logExpressResponseWarning(httpStatusCode, problemJson);
     res.status(httpStatusCode).json(problemJson);
     return true;
   }

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,7 +1,7 @@
 import { ProblemJson } from "@pagopa/ts-commons/lib/responses";
 import { unknownToString } from "./error";
 
-export const logExpressWarning = (
+export const logExpressResponseWarning = (
   statusCode: number,
   problemJson: ProblemJson | object
 ) => {
@@ -10,16 +10,18 @@ export const logExpressWarning = (
     "title" in problemJson ||
     "detail" in problemJson
   ) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `\x1b[1;38;5;202m\n  Http Status Code: ${statusCode}\n  Http Body:\n    Status: ${problemJson.status}\n    Title: ${problemJson.title}\n    Details: ${problemJson.detail}\n\x1b[0m`
+    logWarning(
+      `\n  Http Status Code: ${statusCode}\n  Http Body:\n    Status: ${problemJson.status}\n    Title: ${problemJson.title}\n    Details: ${problemJson.detail}\n`
     );
   } else {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `\x1b[1;38;5;202m\n  Http Status Code: ${statusCode}\n  Http Body:\n    ${unknownToString(
+    logWarning(
+      `\n  Http Status Code: ${statusCode}\n  Http Body:\n    ${unknownToString(
         problemJson
-      )}\n\x1b[0m`
+      )}\n`
     );
   }
 };
+
+export const logWarning = (
+  message: string // eslint-disable-next-line no-console
+) => console.warn(`\x1b[1;38;5;202m${message}\x1b[0m`);


### PR DESCRIPTION
## Short description
This PR adds a non-blocking check (and warning) for the query parameter `isTest=true|false` on IO AAR endpoints

## List of changes proposed in this pull request
Non-blocking check (with console warning) for the `isTest=true|false` parameter on the following endpoints:
- `/api/v1/send/aar`
- `/api/v1/send/notification/:iun`
- `/api/v1/send/notification/attachment/*`
- `/api/v1/send/mandate/create`
- `/api/v1/send/mandate/accept/:mandateId`

Console warninig log refactor to allow logging of a single message or an ExpressFailure type response.

## How to test
Call the endpoints above and check that:
- with no `isTest` parameter, a warning message is printed in the console
- with `isTest` parameter that has a value that is not `true` nor `false`, a warning message is printed in the console
- with `isTest=[true|false]` parameter, no warning message is logged (check for both uppercase, lowercase and mixed)
