### PR TITLE
fix: [IOCOM-2585] Fix for `x-pagopa-pn-io-src` header and 403 on AAR QRCode not belonging to user

### DIFF
--- a/src/features/messages/services/ioSendService.ts
+++ b/src/features/messages/services/ioSendService.ts
@@ -22,9 +22,21 @@ export const generateRequestHeaders = (
   ...MessagesService.sendTaxIdHeader(
     ioDevServerConfig.profile.attrs.fiscal_code
   ),
-  // Don't send the default IO Source Header, it must come from the client
-  "Content-Type": contentTypeHeaderFromHeaders(headers, contentType)
+  "Content-Type": contentTypeHeaderFromHeaders(headers, contentType),
+  ...ioSourceHeaderFromRequestHeaders(headers)
 });
+
+export const ioSourceHeaderFromRequestHeaders = (
+  headers: IncomingHttpHeaders
+): Record<string, string> => {
+  const ioSourceHeader = headers["x-pagopa-pn-io-src"];
+  if (ioSourceHeader != null && typeof ioSourceHeader === "string") {
+    return {
+      "x-pagopa-pn-io-src": ioSourceHeader
+    };
+  }
+  return {};
+};
 
 export const contentTypeHeaderFromHeaders = (
   headers: IncomingHttpHeaders,

--- a/src/features/pn/services/aarService.ts
+++ b/src/features/pn/services/aarService.ts
@@ -48,7 +48,7 @@ export const notificationOrMandateDataFromQRCode = (
     );
     if (mandates.length === 0) {
       return left({
-        httpStatusCode: 401,
+        httpStatusCode: 403,
         reason: {
           iun: notificationIUN,
           denomination: fakeDenominationFromFiscalCode(


### PR DESCRIPTION
## Short description
This PR fixes the `x-pagopa-pn-io-src` header and a bad response code for the QRCode API.

## List of changes proposed in this pull request
- `x-pagopa-pn-io-src` header's value was not being transferred from client to SEND router
- 403 is returned when an AAR QRCode not belonging to the user is requested

## How to test
Request a notification (IO Endpoint) without the `x-pagopa-pn-io-src` header set: a warning should appear in the console. Check it again with the value of such header set to "QRCODE": no warning should appear
Check the AAR endpoint (IO Endpoint) with a QRCode content that does not belong to the user: it should return 403.
