### PR TITLE
feat: [IOBP-1985] Add user onboarded initiative list statuses API

### DIFF
--- a/src/payloads/features/idpay/check-prerequisites.ts
+++ b/src/payloads/features/idpay/check-prerequisites.ts
@@ -174,7 +174,7 @@ const checkPrerequisites: {
               "Hai diritto fino a 200€. Verificheremo questa informazione con INPS"
           },
           {
-            description: "Sì, inferiore a 25.000€",
+            description: "Sì, uguale o superiore a 25.000€",
             subDescription: "Hai diritto fino a 100€"
           },
           {

--- a/src/payloads/features/idpay/get-initiative-data.ts
+++ b/src/payloads/features/idpay/get-initiative-data.ts
@@ -2,7 +2,11 @@ import { fakerIT as faker } from "@faker-js/faker";
 import * as O from "fp-ts/lib/Option";
 import { ulid } from "ulid";
 import { InitiativeDataDTO } from "../../../../generated/definitions/idpay/InitiativeDataDTO";
-import { IDPayInitiativeID, IDPayServiceID } from "./types";
+import {
+  IDPayInitiativeID,
+  IDPayServiceID,
+  InitiativeDataDTOWithServiceId
+} from "./types";
 import { initiativeIdToString } from "./utils";
 
 const createRandomInitiativeDataDTO = (): InitiativeDataDTO => ({
@@ -134,3 +138,22 @@ const initiativeData: {
 export const getInitiativeDataResponseByServiceId = (
   id: IDPayServiceID
 ): O.Option<InitiativeDataDTO> => O.fromNullable(initiativeData[id]);
+
+export const getInitiativeDataResponseByInitiativeId = (
+  initiativeId: number
+): InitiativeDataDTOWithServiceId | undefined => {
+  const entry = Object.entries(initiativeData).find(
+    ([, data]) => data.initiativeId === initiativeIdToString(initiativeId)
+  );
+
+  if (!entry) {
+    return undefined;
+  }
+
+  const [serviceId, data] = entry;
+
+  return {
+    ...data,
+    serviceId
+  };
+};

--- a/src/payloads/features/idpay/get-onboarding-initiative-user-status.ts
+++ b/src/payloads/features/idpay/get-onboarding-initiative-user-status.ts
@@ -1,0 +1,13 @@
+import * as O from "fp-ts/lib/Option";
+import { pipe } from "fp-ts/lib/function";
+import { onboardedInitiativeStatuses } from "../../../persistence/idpay";
+import { UserOnboardingStatusDTO } from "../../../../generated/definitions/idpay/UserOnboardingStatusDTO";
+
+export const getOnboardingInitiativeUserStatus = (): O.Option<
+  UserOnboardingStatusDTO[]
+> =>
+  pipe(
+    onboardedInitiativeStatuses,
+    O.fromNullable,
+    O.map(el => el)
+  );

--- a/src/payloads/features/idpay/types.ts
+++ b/src/payloads/features/idpay/types.ts
@@ -1,3 +1,5 @@
+import { InitiativeDataDTO } from "../../../../generated/definitions/idpay/InitiativeDataDTO";
+
 export enum IDPayServiceID {
   OK = 1,
 
@@ -49,3 +51,7 @@ export enum IDPayInitiativeID {
   KO_FAMILY_UNIT_ALREADY_JOINED,
   KO_TOO_MANY_REQUESTS
 }
+
+export type InitiativeDataDTOWithServiceId = InitiativeDataDTO & {
+  serviceId: string;
+};

--- a/src/persistence/idpay.ts
+++ b/src/persistence/idpay.ts
@@ -64,6 +64,10 @@ import {
   VoucherStatusEnum,
   StatusEnum as InitiativeStatusEnum
 } from "../../generated/definitions/idpay/InitiativeDTO";
+import {
+  StatusEnum as OnboardedInitiativeStatusEnum,
+  UserOnboardingStatusDTO
+} from "../../generated/definitions/idpay/UserOnboardingStatusDTO";
 
 const idPayConfig = ioDevServerConfig.features.idpay;
 const { idPay: walletConfig } = ioDevServerConfig.wallet;
@@ -733,4 +737,32 @@ export const getIdPayBarcodeTransaction = (
     }
     return currentBarcode;
   }
+};
+
+// ==== Onboarded Initiative Statuses ====
+// eslint-disable-next-line functional/no-let
+export let onboardedInitiativeStatuses: UserOnboardingStatusDTO[] = [];
+
+export const addOnboardedInitiativeStatus = (
+  initiative: InitiativeDTO,
+  status: OnboardedInitiativeStatusEnum
+) => {
+  if (
+    onboardedInitiativeStatuses.find(
+      onboardedInitiative =>
+        onboardedInitiative.initiativeId === initiative.initiativeId
+    )
+  ) {
+    return;
+  }
+  onboardedInitiativeStatuses = [
+    ...onboardedInitiativeStatuses,
+    {
+      initiativeId: initiative.initiativeId,
+      initiativeName: initiative.initiativeName ?? "",
+      serviceId: initiative.serviceId ?? "",
+      status,
+      statusDate: new Date()
+    }
+  ];
 };

--- a/src/persistence/idpay.ts
+++ b/src/persistence/idpay.ts
@@ -68,6 +68,7 @@ import {
   StatusEnum as OnboardedInitiativeStatusEnum,
   UserOnboardingStatusDTO
 } from "../../generated/definitions/idpay/UserOnboardingStatusDTO";
+import { InitiativeDataDTOWithServiceId } from "../payloads/features/idpay/types";
 
 const idPayConfig = ioDevServerConfig.features.idpay;
 const { idPay: walletConfig } = ioDevServerConfig.wallet;
@@ -744,10 +745,11 @@ export const getIdPayBarcodeTransaction = (
 export let onboardedInitiativeStatuses: UserOnboardingStatusDTO[] = [];
 
 export const addOnboardedInitiativeStatus = (
-  initiative: InitiativeDTO,
+  initiative: InitiativeDataDTOWithServiceId | undefined,
   status: OnboardedInitiativeStatusEnum
 ) => {
   if (
+    !initiative ||
     onboardedInitiativeStatuses.find(
       onboardedInitiative =>
         onboardedInitiative.initiativeId === initiative.initiativeId

--- a/src/routers/features/idpay/onboarding.ts
+++ b/src/routers/features/idpay/onboarding.ts
@@ -9,17 +9,17 @@ import {
   getPrerequisitesErrorByInitiativeId
 } from "../../../payloads/features/idpay/check-prerequisites";
 import { getIdPayError } from "../../../payloads/features/idpay/error";
-import { getInitiativeDataResponseByServiceId } from "../../../payloads/features/idpay/get-initiative-data";
+import {
+  getInitiativeDataResponseByInitiativeId,
+  getInitiativeDataResponseByServiceId
+} from "../../../payloads/features/idpay/get-initiative-data";
 import { getOnboardingStatusResponseByInitiativeId } from "../../../payloads/features/idpay/onboarding-status";
 import {
   initiativeIdFromString,
   serviceIdFromString
 } from "../../../payloads/features/idpay/utils";
 import { OnboardingDTO } from "../../../../generated/definitions/idpay/OnboardingDTO";
-import {
-  addOnboardedInitiativeStatus,
-  initiatives
-} from "../../../persistence/idpay";
+import { addOnboardedInitiativeStatus } from "../../../persistence/idpay";
 import { StatusEnum as OnboardedInitiativeStatusEnum } from "../../../../generated/definitions/idpay/UserOnboardingStatusDTO";
 import { getOnboardingInitiativeUserStatus } from "../../../payloads/features/idpay/get-onboarding-initiative-user-status";
 import { addIdPayHandler } from "./router";
@@ -118,7 +118,7 @@ addIdPayHandler("put", "/onboarding/", (req, res) =>
               O.fold(
                 () => {
                   addOnboardedInitiativeStatus(
-                    initiatives[initiativeId],
+                    getInitiativeDataResponseByInitiativeId(initiativeId),
                     OnboardedInitiativeStatusEnum.ON_WAITING_LIST
                   );
                   return res.sendStatus(202);
@@ -144,7 +144,7 @@ addIdPayHandler("get", "/onboarding/user/initiative/status", (req, res) =>
           code: OnboardingErrorCodeEnum.ONBOARDING_INVALID_REQUEST,
           message: ""
         } as OnboardingErrorDTO),
-      status => res.status(200).json(status)
+      response => res.status(200).json(response)
     )
   )
 );


### PR DESCRIPTION
## Short description
This PR introduces enhancements to the IDPay onboarding and initiative management features. The improvements include the ability to track and retrieve user-initiated onboardings that are on the waiting list.

## List of changes proposed in this pull request
* Added a new in-memory store (`onboardedInitiativeStatuses`) to track the onboarding status of users for initiatives, along with a function `addOnboardedInitiativeStatus` to update this store.
* Introduced the `getOnboardingInitiativeUserStatus` function to retrieve all initiatives for which the user is in the waiting list or evaluation status, and exposed a new GET endpoint `/onboarding/user/initiative/status` to return this data.
* Updated the onboarding PUT handler to add the user to the waiting list when prerequisites are met, using the new tracking mechanism.

## How to test
- Start an onboarding of an initiative on the io-app and check that when you complete the onboarding process, there is a new element inside the `onboardedInitiativeStatuses` list
