### PR TITLE
feat: Remove `cie_id` FF definition from the generated content definition file

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,14 +2,14 @@
 
 IO_BACKEND_VERSION=v16.17.0
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.79
+IO_SERVICES_METADATA_VERSION=1.0.82
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.8.0
 
 declare -a noParams=(
   "./generated/definitions/backend https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_public.yaml"
   "./generated/definitions/session_manager https://raw.githubusercontent.com/pagopa/io-auth-n-identity-domain/io-session-manager@$IO_SESSION_MANAGER_VERSION/apps/io-session-manager/api/external.yaml"
-  "./generated/definitions/content https://raw.githubusercontent.com/pagopa/io-services-metadata/refs/heads/IOPID-2649-remove-cieid-ff/definitions.yml"
+  "./generated/definitions/content https://raw.githubusercontent.com/pagopa/io-services-metadata/$IO_SERVICES_METADATA_VERSION/definitions.yml"
   "./generated/definitions/pagopa/cobadge/configuration https://raw.githubusercontent.com/pagopa/io-services-metadata/$IO_SERVICES_METADATA_VERSION/pagopa/cobadge/abi_definitions.yml"
   "./generated/definitions/pagopa/privative/configuration https://raw.githubusercontent.com/pagopa/io-services-metadata/$IO_SERVICES_METADATA_VERSION/pagopa/privative/definitions.yml"
   "./generated/definitions/pagopa/walletv2 https://raw.githubusercontent.com/pagopa/io-services-metadata/$IO_SERVICES_METADATA_VERSION/bonus/specs/bpd/pm/walletv2.json"


### PR DESCRIPTION
> [!WARNING]
> Depends on https://github.com/pagopa/io-services-metadata/pull/1025 

## Short description
This PR upgrades the `IO_SESSION_MANAGER_VERSION` to remove the `cie_id` FF definition from the generated content definition file

## List of changes proposed in this pull request
- Upgraded `IO_SESSION_MANAGER_VERSION` to `1.0.82` 

## How to test
After running the `yarn generate` command, execute a `yarn tsc:noemit`. If everything goes well, you can start the dev server and test, with the help of the IO app, that everything works correctly

