### PR TITLE
chore: [IOBP-2026] CdC dark mode hero image

### DIFF
--- a/assets/bonus_available/bonus_available_v2.json
+++ b/assets/bonus_available/bonus_available_v2.json
@@ -64,6 +64,7 @@
     "valid_to": "2022-12-31T00:00:00.000Z",
     "cover": "https://assets.cdn.io.pagopa.it/bonus/cdc/logo/logo-cdc.png",
     "hero_image": "https://assets.cdn.io.pagopa.it/bonus/cdc/logo/hero-cdc.png",
+    "hero_image_dark": "https://raw.githubusercontent.com/pagopa/io-services-metadata/refs/heads/IOBP-2024-dark-hero-image/bonus/cdc/logo/hero-cdc-dark.png",
     "sponsorship_description": "Ministero della Cultura",
     "sponsorship_cover": "https://assets.cdn.io.pagopa.it/bonus/cdc/logo/logo-cdc.png"
   }


### PR DESCRIPTION
> [!NOTE]
> Depends on https://github.com/pagopa/io-services-metadata/pull/1030 

## Short description
This pull request introduces a new property for dark mode support for CdC card

## List of changes proposed in this pull request
- Added the `hero_image_dark` property with a URL pointing to the dark-themed hero image for the bonus, improving support for dark mode interfaces

## How to test
- Test the CdC onboarding flow with dark mode enabled
- Ensure that logo is visible