### PR TITLE
feat: [IEL-185] Fci flow with generated nonce

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -105,7 +105,7 @@ const defaultConfig: IoDevServerConfig = {
       response: {
         getFciResponseCode: 200,
         documentExpirationDurationSeconds: 5 * 60, // make it 30 to allow testing expired documents without waiting too much
-        nonceDuration: 5 * 60 // 5 minutes as production environment
+        nonceDurationSeconds: 5 * 60 // 5 minutes as production environment
       }
     },
     withCTA: false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,7 +103,8 @@ const defaultConfig: IoDevServerConfig = {
       canceledCount: 0,
       noSignatureFieldsCount: 0,
       response: {
-        getFciResponseCode: 200
+        getFciResponseCode: 200,
+        nonceDuration: 300 // 5 minutes as production environment
       }
     },
     withCTA: false,

--- a/src/features/fci/qtspNonceStore.ts
+++ b/src/features/fci/qtspNonceStore.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "crypto";
 import { ioDevServerConfig } from "../../config";
 
 export const QTSP_NONCE_EXPIRING_MS =
-  ioDevServerConfig.messages.fci.response.nonceDuration * 1000;
+  ioDevServerConfig.messages.fci.response.nonceDurationSeconds * 1000;
 
 const qtspNonceExpirations = new Map<string, Date>();
 

--- a/src/features/fci/qtspNonceStore.ts
+++ b/src/features/fci/qtspNonceStore.ts
@@ -1,0 +1,56 @@
+import { randomUUID } from "crypto";
+import { ioDevServerConfig } from "../../config";
+
+export const QTSP_NONCE_EXPIRING_MS =
+  ioDevServerConfig.messages.fci.response.nonceDuration * 1000;
+
+const qtspNonceExpirations = new Map<string, Date>();
+
+const cleanupExpiredQtspNonces = (referenceDate: Date) => {
+  qtspNonceExpirations.forEach((expiresAt, nonce) => {
+    if (expiresAt <= referenceDate) {
+      qtspNonceExpirations.delete(nonce);
+    }
+  });
+};
+
+const generateQtspNonce = () =>
+  `devnonce-${randomUUID({ disableEntropyCache: true })}`;
+
+export const generateAndStoreQtspNonce = (now = new Date()) => {
+  cleanupExpiredQtspNonces(now);
+  const nonce = generateQtspNonce();
+  qtspNonceExpirations.set(
+    nonce,
+    new Date(now.getTime() + QTSP_NONCE_EXPIRING_MS)
+  );
+  return nonce;
+};
+
+export type QtspNonceValidationResult = "valid" | "expired" | "missing";
+
+export const getQtspNonceValidationResult = (
+  nonce: string,
+  now = new Date()
+): QtspNonceValidationResult => {
+  const expiration = qtspNonceExpirations.get(nonce);
+
+  if (expiration === undefined) {
+    cleanupExpiredQtspNonces(now);
+    return "missing";
+  }
+
+  if (expiration <= now) {
+    qtspNonceExpirations.delete(nonce);
+    cleanupExpiredQtspNonces(now);
+    return "expired";
+  }
+
+  cleanupExpiredQtspNonces(now);
+  return "valid";
+};
+
+export const isStoredQtspNonceValid = (nonce: string, now = new Date()) =>
+  getQtspNonceValidationResult(nonce, now) === "valid";
+
+export const getQtspNonceExpirations = () => qtspNonceExpirations;

--- a/src/features/fci/qtspNonceStore.ts
+++ b/src/features/fci/qtspNonceStore.ts
@@ -6,9 +6,10 @@ export const QTSP_NONCE_EXPIRING_MS =
 
 const qtspNonceExpirations = new Map<string, Date>();
 
-const cleanupExpiredQtspNonces = (referenceDate: Date) => {
+const cleanupExpiredQtspNonces = () => {
+  const now = new Date();
   qtspNonceExpirations.forEach((expiresAt, nonce) => {
-    if (expiresAt <= referenceDate) {
+    if (expiresAt <= now) {
       qtspNonceExpirations.delete(nonce);
     }
   });
@@ -18,7 +19,7 @@ const generateQtspNonce = () =>
   `devnonce-${randomUUID({ disableEntropyCache: true })}`;
 
 export const generateAndStoreQtspNonce = (now = new Date()) => {
-  cleanupExpiredQtspNonces(now);
+  cleanupExpiredQtspNonces();
   const nonce = generateQtspNonce();
   qtspNonceExpirations.set(
     nonce,
@@ -27,30 +28,10 @@ export const generateAndStoreQtspNonce = (now = new Date()) => {
   return nonce;
 };
 
-export type QtspNonceValidationResult = "valid" | "expired" | "missing";
-
-export const getQtspNonceValidationResult = (
-  nonce: string,
-  now = new Date()
-): QtspNonceValidationResult => {
+export const validateQtspNonce = (nonce: string): boolean => {
+  cleanupExpiredQtspNonces();
   const expiration = qtspNonceExpirations.get(nonce);
-
-  if (expiration === undefined) {
-    cleanupExpiredQtspNonces(now);
-    return "missing";
-  }
-
-  if (expiration <= now) {
-    qtspNonceExpirations.delete(nonce);
-    cleanupExpiredQtspNonces(now);
-    return "expired";
-  }
-
-  cleanupExpiredQtspNonces(now);
-  return "valid";
+  return !expiration === undefined;
 };
-
-export const isStoredQtspNonceValid = (nonce: string, now = new Date()) =>
-  getQtspNonceValidationResult(nonce, now) === "valid";
 
 export const getQtspNonceExpirations = () => qtspNonceExpirations;

--- a/src/features/fci/qtspNonceStore.ts
+++ b/src/features/fci/qtspNonceStore.ts
@@ -31,7 +31,7 @@ export const generateAndStoreQtspNonce = (now = new Date()) => {
 export const validateQtspNonce = (nonce: string): boolean => {
   cleanupExpiredQtspNonces();
   const expiration = qtspNonceExpirations.get(nonce);
-  return !expiration === undefined;
+  return expiration !== undefined;
 };
 
 export const getQtspNonceExpirations = () => qtspNonceExpirations;

--- a/src/features/messages/types/messagesConfig.ts
+++ b/src/features/messages/types/messagesConfig.ts
@@ -38,7 +38,7 @@ export const MessagesConfig = t.intersection([
         // 200 success with payload
         getFciResponseCode: HttpResponseCode,
         // qtsp nonce duration in seconds
-        nonceDuration: t.number,
+        nonceDurationSeconds: t.number,
         documentExpirationDurationSeconds: t.number
       })
     }),

--- a/src/features/messages/types/messagesConfig.ts
+++ b/src/features/messages/types/messagesConfig.ts
@@ -36,7 +36,9 @@ export const MessagesConfig = t.intersection([
       noSignatureFieldsCount: t.number,
       response: t.type({
         // 200 success with payload
-        getFciResponseCode: HttpResponseCode
+        getFciResponseCode: HttpResponseCode,
+        // qtsp nonce duration in seconds
+        nonceDuration: t.number
       })
     }),
     // if true, messages (all available) with nested CTA will be included

--- a/src/routers/features/fci/__tests__/index.test.ts
+++ b/src/routers/features/fci/__tests__/index.test.ts
@@ -6,6 +6,7 @@ import { SIGNATURE_REQUEST_ID } from "../../../../payloads/features/fci/signatur
 import app from "../../../../server";
 import { addFciPrefix } from "../index";
 import { EnvironmentEnum } from "../../../../../generated/definitions/fci/Environment";
+import { getQtspNonceExpirations } from "../../../../features/fci/qtspNonceStore";
 
 const request = supertest(app);
 
@@ -47,11 +48,30 @@ describe("io-sign API", () => {
     });
   });
   describe("GET qtsp clauses", () => {
+    beforeEach(() => {
+      getQtspNonceExpirations().clear();
+    });
+
     describe("when the signer request qtsp clauses", () => {
       it("should return 200 and the clauses list", async () => {
         const response = await request.get(addFciPrefix(`/qtsp/clauses`));
         expect(response.status).toBe(200);
         expect(response.body).toHaveProperty("clauses");
+        expect(response.body.nonce).toMatch(/^devnonce-/);
+        expect(getQtspNonceExpirations().has(response.body.nonce)).toBe(true);
+      });
+
+      it("should store the nonce with an expiration date", async () => {
+        const response = await request.get(addFciPrefix(`/qtsp/clauses`));
+        const nonceExpiration = getQtspNonceExpirations().get(
+          response.body.nonce
+        );
+
+        if (nonceExpiration === undefined) {
+          throw new Error("missing nonce expiration");
+        }
+
+        expect(nonceExpiration.getTime()).toBeGreaterThan(Date.now());
       });
     });
   });
@@ -67,12 +87,53 @@ describe("io-sign API", () => {
     });
   });
   describe("POST create signature", () => {
+    beforeEach(() => {
+      getQtspNonceExpirations().clear();
+    });
+
     describe("when the signer request a signature with a valid body", () => {
-      it("should return 201", async () => {
+      it("should return 200", async () => {
+        const qtspClausesResponse = await request.get(
+          addFciPrefix(`/qtsp/clauses`)
+        );
+        const response = await request.post(addFciPrefix(`/signatures`)).send({
+          ...createSignatureBody,
+          qtsp_clauses: {
+            ...createSignatureBody.qtsp_clauses,
+            nonce: qtspClausesResponse.body.nonce
+          }
+        });
+        expect(response.status).toBe(200);
+      });
+    });
+    describe("when the signer request a signature with an invalid nonce", () => {
+      it("should return 500", async () => {
         const response = await request
           .post(addFciPrefix(`/signatures`))
           .send(createSignatureBody);
-        expect(response.status).toBe(200);
+        expect(response.status).toBe(500);
+      });
+    });
+    describe("when the signer request a signature with an expired nonce", () => {
+      it("should return 500", async () => {
+        const qtspClausesResponse = await request.get(
+          addFciPrefix(`/qtsp/clauses`)
+        );
+        const expiredNonce = qtspClausesResponse.body.nonce;
+        getQtspNonceExpirations().set(
+          expiredNonce,
+          new Date(Date.now() - 1000)
+        );
+
+        const response = await request.post(addFciPrefix(`/signatures`)).send({
+          ...createSignatureBody,
+          qtsp_clauses: {
+            ...createSignatureBody.qtsp_clauses,
+            nonce: expiredNonce
+          }
+        });
+
+        expect(response.status).toBe(500);
       });
     });
     describe("when the signer request signature detail with a not valid body", () => {

--- a/src/routers/features/fci/__tests__/index.test.ts
+++ b/src/routers/features/fci/__tests__/index.test.ts
@@ -111,7 +111,7 @@ describe("io-sign API", () => {
         const response = await request
           .post(addFciPrefix(`/signatures`))
           .send(createSignatureBody);
-        expect(response.status).toBe(500);
+        expect(response.status).toBe(400);
       });
     });
     describe("when the signer request a signature with an expired nonce", () => {

--- a/src/routers/features/fci/__tests__/index.test.ts
+++ b/src/routers/features/fci/__tests__/index.test.ts
@@ -87,6 +87,8 @@ describe("io-sign API", () => {
     });
   });
   describe("POST create signature", () => {
+    const SHOULD_RETURN_400 = "should return 400";
+
     beforeEach(() => {
       getQtspNonceExpirations().clear();
     });
@@ -107,7 +109,7 @@ describe("io-sign API", () => {
       });
     });
     describe("when the signer request a signature with an invalid nonce", () => {
-      it("should return 500", async () => {
+      it(SHOULD_RETURN_400, async () => {
         const response = await request
           .post(addFciPrefix(`/signatures`))
           .send(createSignatureBody);
@@ -115,7 +117,7 @@ describe("io-sign API", () => {
       });
     });
     describe("when the signer request a signature with an expired nonce", () => {
-      it("should return 500", async () => {
+      it(SHOULD_RETURN_400, async () => {
         const qtspClausesResponse = await request.get(
           addFciPrefix(`/qtsp/clauses`)
         );
@@ -133,11 +135,11 @@ describe("io-sign API", () => {
           }
         });
 
-        expect(response.status).toBe(500);
+        expect(response.status).toBe(400);
       });
     });
     describe("when the signer request signature detail with a not valid body", () => {
-      it("should return 400", async () => {
+      it(SHOULD_RETURN_400, async () => {
         const response = await request.post(addFciPrefix(`/signatures`));
         expect(response.status).toBe(400);
       });

--- a/src/routers/features/fci/index.ts
+++ b/src/routers/features/fci/index.ts
@@ -181,7 +181,12 @@ addHandler(fciRouter, "post", addFciPrefix("/signatures"), (req, res) => {
         if (nonceValidationResult === "valid") {
           return res.status(200).json(mockSignatureDetailView);
         }
-        return res.sendStatus(500);
+        return res.status(400).json({
+          detail:
+            "An error occurred while validating the request body | undefined",
+          status: 400,
+          title: "Invalid request"
+        });
       }
     )
   );

--- a/src/routers/features/fci/index.ts
+++ b/src/routers/features/fci/index.ts
@@ -27,7 +27,7 @@ import { signatureRequestList } from "../../../payloads/features/fci/signature-r
 import { getProblemJson } from "../../../payloads/error";
 import {
   generateAndStoreQtspNonce,
-  getQtspNonceValidationResult
+  validateQtspNonce
 } from "../../../features/fci/qtspNonceStore";
 
 export const fciRouter = Router();
@@ -172,13 +172,13 @@ addHandler(fciRouter, "post", addFciPrefix("/signatures"), (req, res) => {
     O.chain(cb =>
       pipe(
         O.fromNullable(cb.qtsp_clauses?.nonce),
-        O.map(nonce => getQtspNonceValidationResult(nonce))
+        O.map(nonce => validateQtspNonce(nonce))
       )
     ),
     O.fold(
       () => res.sendStatus(400),
       nonceValidationResult => {
-        if (nonceValidationResult === "valid") {
+        if (nonceValidationResult) {
           return res.status(200).json(mockSignatureDetailView);
         }
         return res.status(400).json({

--- a/src/routers/features/fci/index.ts
+++ b/src/routers/features/fci/index.ts
@@ -25,6 +25,10 @@ import { SignatureRequestStatusEnum } from "../../../../generated/definitions/fc
 import { EnvironmentEnum } from "../../../../generated/definitions/fci/Environment";
 import { signatureRequestList } from "../../../payloads/features/fci/signature-requests";
 import { getProblemJson } from "../../../payloads/error";
+import {
+  generateAndStoreQtspNonce,
+  getQtspNonceValidationResult
+} from "../../../features/fci/qtspNonceStore";
 
 export const fciRouter = Router();
 const configResponse = ioDevServerConfig.messages.fci.response;
@@ -128,7 +132,7 @@ addHandler(
 );
 
 addHandler(fciRouter, "get", addFciPrefix("/qtsp/clauses"), (_, res) => {
-  res.status(200).json(qtspClauses);
+  res.status(200).json({ ...qtspClauses, nonce: generateAndStoreQtspNonce() });
 });
 
 addHandler(
@@ -151,9 +155,20 @@ addHandler(fciRouter, "post", addFciPrefix("/signatures"), (req, res) => {
   pipe(
     O.fromNullable(req.body),
     O.chain(cb => (isEqual(cb, {}) ? O.none : O.some(cb))),
+    O.chain(cb =>
+      pipe(
+        O.fromNullable(cb.qtsp_clauses?.nonce),
+        O.map(nonce => getQtspNonceValidationResult(nonce))
+      )
+    ),
     O.fold(
       () => res.sendStatus(400),
-      _ => res.status(200).json(mockSignatureDetailView)
+      nonceValidationResult => {
+        if (nonceValidationResult === "valid") {
+          return res.status(200).json(mockSignatureDetailView);
+        }
+        return res.sendStatus(500);
+      }
     )
   );
 });


### PR DESCRIPTION
## Short description
This PR introduces nonce lifecycle handling for the FCI sign flow, allowing to test the IO app behaviour with expired nonce running it with local configuration.

## List of changes proposed in this pull request
- Updated GET `/api/v1/sign/qtsp/clauses` to generate and return a fresh nonce, storing its expiration.
- Updated POST `/api/v1/sign/signatures` to validate `qtsp_clauses.nonce` and return an error (500) when nonce is not valid.
- Extended FCI router tests to cover nonce validation.

## How to test
Run the IO app with .env.local, then start the FCI signing flow (the dev-server config must include at least one fci.waitForSignatureCount). Stop at any step before final signing. After the nonce validity window (fci.response.nonceDuration) has expired, try to complete the signature: POST /api/v1/sign/signatures should return 500, and the app should show an error message with a button to restart the signing flow.
