### PR TITLE
refactor: [IEG-2787] Align backend tags and refactor endpoint paths

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -7,6 +7,8 @@ IO_SERVICES_METADATA_VERSION=1.0.99
 IO_SESSION_MANAGER_VERSION=1.23.1
 # Send Functions
 IO_SEND_FUNC=1.5.5
+# CGN and CDC APIs are generated with a different version of io-backend, so we need to specify it separately
+IO_BACKEND_VERSION_CGN_CDC=v19.0.0
 
 declare -a noParams=(
   "./generated/definitions/backend https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_public.yaml"
@@ -20,10 +22,10 @@ declare -a noParams=(
   "./generated/definitions/pagopa/transactions https://raw.githubusercontent.com/pagopa/pagopa-biz-events-service/refs/tags/0.1.87/openapi/openapi_lap_jwt.json"
   "./generated/definitions/pagopa/platform https://raw.githubusercontent.com/pagopa/pagopa-infra/v1.64.0/src/domains/shared-app/api/session-wallet/v1/_openapi.json.tpl"
   "./generated/definitions/pagopa https://raw.githubusercontent.com/pagopa/io-app/master/assets/paymentManager/spec.json"
-  "./generated/definitions/cgn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_cgn.yaml"
-  "./generated/definitions/cgn/merchants https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_cgn_operator_search.yaml"
+  "./generated/definitions/cgn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION_CGN_CDC/openapi/generated/api_cgn_card_platform.yaml"
+  "./generated/definitions/cgn/merchants https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION_CGN_CDC/openapi/generated/api_cgn_search_platform.yaml"
   "./generated/definitions/cgn/geo https://raw.githubusercontent.com/pagopa/io-backend/here_geoapi_integration/api_geo.yaml"
-  "./generated/definitions/cdc https://raw.githubusercontent.com/pagopa/io-backend/refs/tags/$IO_BACKEND_VERSION/openapi/generated/api_cdc.yaml"
+  "./generated/definitions/cdc https://raw.githubusercontent.com/pagopa/io-backend/refs/tags/$IO_BACKEND_VERSION_CGN_CDC/openapi/generated/api_cdc_support_platform.yaml"
 )
 
 declare -a noStrict=(

--- a/src/features/cdc/routers/router.ts
+++ b/src/features/cdc/routers/router.ts
@@ -3,7 +3,7 @@ import { addHandler, SupportedMethod } from "../../../payloads/response";
 
 export const cdcRouter = Router();
 
-export const CDC_PREFIX = "/api/v1/cdc";
+export const CDC_PREFIX = "/api/cdc-support/v1";
 
 const addCdcPrefix = (path: string) => `${CDC_PREFIX}${path}`;
 

--- a/src/routers/features/cgn/index.ts
+++ b/src/routers/features/cgn/index.ts
@@ -30,7 +30,7 @@ import { getRandomStringId } from "../../../utils/id";
 import { getRandomValue } from "../../../utils/random";
 
 export const cgnRouter = Router();
- 
+
 const CGN_PREFIX = "/api/cgn-card/v1";
 
 const addPrefix = (path: string) => `${CGN_PREFIX}${path}`;

--- a/src/routers/features/cgn/index.ts
+++ b/src/routers/features/cgn/index.ts
@@ -23,16 +23,17 @@ import { EycaCard } from "../../../../generated/definitions/cgn/EycaCard";
 import { Otp } from "../../../../generated/definitions/cgn/Otp";
 import { ioDevServerConfig } from "../../../config";
 import { genRandomOtpCode } from "../../../features/cgn/utils";
-import { addHandler } from "../../../payloads/response";
 import { cgnServiceId } from "../../../features/services/persistence/services/special/cgn-service";
+import ServicesDB from "../../../features/services/persistence/servicesDatabase";
+import { addHandler } from "../../../payloads/response";
 import { getRandomStringId } from "../../../utils/id";
 import { getRandomValue } from "../../../utils/random";
-import { addApiV1Prefix } from "../../../utils/strings";
-import ServicesDB from "../../../features/services/persistence/servicesDatabase";
 
 export const cgnRouter = Router();
+ 
+const CGN_PREFIX = "/api/cgn-card/v1";
 
-const addPrefix = (path: string) => addApiV1Prefix(`/cgn${path}`);
+const addPrefix = (path: string) => `${CGN_PREFIX}${path}`;
 
 // eslint-disable-next-line functional/no-let
 let idActivationCgn: string | undefined;

--- a/src/routers/features/cgn/merchants.ts
+++ b/src/routers/features/cgn/merchants.ts
@@ -6,12 +6,14 @@ import * as O from "fp-ts/lib/Option";
 import { contramap } from "fp-ts/lib/Ord";
 import { Ord } from "fp-ts/lib/boolean";
 import { pipe } from "fp-ts/lib/function";
+
 import { DiscountBucketCode } from "../../../../generated/definitions/cgn/merchants/DiscountBucketCode";
 import { OfflineMerchant } from "../../../../generated/definitions/cgn/merchants/OfflineMerchant";
 import { OfflineMerchantSearchRequest } from "../../../../generated/definitions/cgn/merchants/OfflineMerchantSearchRequest";
 import { OnlineMerchant } from "../../../../generated/definitions/cgn/merchants/OnlineMerchant";
 import { OnlineMerchantSearchRequest } from "../../../../generated/definitions/cgn/merchants/OnlineMerchantSearchRequest";
 import { ProductCategoryEnum } from "../../../../generated/definitions/cgn/merchants/ProductCategory";
+import { SearchRequest } from "../../../../generated/definitions/cgn/merchants/SearchRequest";
 import { getProblemJson } from "../../../payloads/error";
 import {
   generateMerchantsAll,
@@ -20,14 +22,13 @@ import {
 } from "../../../payloads/features/cgn/merchants";
 import { addHandler } from "../../../payloads/response";
 import { sendFileFromRootPath } from "../../../utils/file";
-import { addApiV1Prefix } from "../../../utils/strings";
 import { publicRouter } from "../../public";
-import { SearchRequest } from "../../../../generated/definitions/cgn/merchants/SearchRequest";
 
 export const cgnMerchantsRouter = Router();
 
-const addPrefix = (path: string) =>
-  addApiV1Prefix(`/cgn/operator-search${path}`);
+const MERCHANTS_PREFIX = "/api/cgn-search/v1";
+
+const addPrefix = (path: string) => `${MERCHANTS_PREFIX}${path}`;
 
 const merchantsAll = generateMerchantsAll();
 


### PR DESCRIPTION
## Short description

This pull request updates the API model generation and refactors the API route prefixes for the CGN and CDC features to align with the latest backend specifications. The main changes involve updating the backend versions used for API generation and modifying the route prefixes across the codebase for consistency with the new OpenAPI definitions.

## List of changes proposed in this pull request
- Changed the backend version used for generating CGN and CDC API models by introducing a new `IO_BACKEND_VERSION_CGN_CDC` variable and updating the relevant URLs in `scripts/generate-api-models.sh`
- Updated the CDC API route prefix from `/api/v1/cdc` to `/api/cdc-support/v1`
- Updated the CGN API route prefix from `/api/v1/cgn` to `/api/cgn-card/v1`
- Updated the CGN merchants search API route prefix from `/api/v1/cgn/operator-search` to `/api/cgn-search/v1` 

## How to test
With this [development](https://github.com/pagopa/io-app/pull/8020), verify that is possible to use both CGN and CDC cards in dev mode