### PR TITLE
chore: [IEG-000] Add emilio-dimari as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
 
-* @pagopa/io-app @ChrisMattew @gispada @soixdev91
+* @pagopa/io-app @ChrisMattew @gispada @soixdev91 @emilio-dimari


### PR DESCRIPTION
> [!WARNING]
> This PR depends on https://github.com/pagopa/eng-github-authorization/pull/3375 

## Short description
This pull request updates the `CODEOWNERS` file to include `@emilio-dimari` as a code owner

## List of changes proposed in this pull request
- Added `@emilio-dimari` as a code owner

## How to test
N/A