### PR TITLE
refactor: [IEG-2882] Update EYCA definitions

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -5,7 +5,7 @@ IO_BACKEND_VERSION=v20.0.0
 # (e.g. api_trial_system.yaml, UserMetadata, ServerInfo from api_backend.yaml)
 IO_BACKEND_LEGACY_VERSION=v17.5.2
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.100
+IO_SERVICES_METADATA_VERSION=IEG-2882-eyca-definitions
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # Send Functions

--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -5,7 +5,7 @@ IO_BACKEND_VERSION=v20.0.0
 # (e.g. api_trial_system.yaml, UserMetadata, ServerInfo from api_backend.yaml)
 IO_BACKEND_LEGACY_VERSION=v17.5.2
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=IEG-2882-eyca-definitions
+IO_SERVICES_METADATA_VERSION=1.0.101
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # Send Functions

--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -81,7 +81,9 @@ export const backendStatus: BackendStatus = {
           },
           url: ""
         }
-      }
+      },
+      eyca_base_url: "https://eyca.org",
+      eyca_discount_url: "https://eyca.org/discounts/it"
     },
     fims: {
       domain: `${serverUrl}/fims/provider/`,

--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -83,7 +83,7 @@ export const backendStatus: BackendStatus = {
         }
       },
       eyca_base_url: "https://eyca.org",
-      eyca_discount_url: "https://eyca.org/discounts/it"
+      eyca_discount_url: "https://eyca.org/discounts?country=IT"
     },
     fims: {
       domain: `${serverUrl}/fims/provider/`,


### PR DESCRIPTION
> [!NOTE]
> This PR depends on https://github.com/pagopa/io-services-metadata/pull/1185

## Short description
This pull request updates configuration values related to the EYCA integration and adds new URLs to the backend status payload.

## List of changes proposed in this pull request
- Added `eyca_base_url` and `eyca_discount_url` fields to the `backendStatus` object
- Update tag version

## How to test
N/A