### PR TITLE
chore: [IOPID-4112] Add OneIdentity config

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -5,7 +5,7 @@ IO_BACKEND_VERSION=v20.0.0
 # (e.g. api_trial_system.yaml, UserMetadata, ServerInfo from api_backend.yaml)
 IO_BACKEND_LEGACY_VERSION=v17.5.2
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.106
+IO_SERVICES_METADATA_VERSION=1.1.1
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # Send Functions

--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -355,6 +355,9 @@ export const backendStatus: BackendStatus = {
         }
       }
     },
+    oneIdentity: {
+      rolloutPercentage: 0
+    },
     emailUniquenessValidation: {
       min_app_version: {
         ios: "0.0.0",


### PR DESCRIPTION
## Short description
This PR adds the OneIdentity configuration to `backendStatus` and updates `IO_SERVICES_METADATA_VERSION` to version `1.1.1`.

## List of changes proposed in this pull request
- Bumped `IO_SERVICES_METADATA_VERSION` to `1.1.1`
- Added oneIdentity config inside `backendStatus`

## How to test
- Check that `backend.json` reflects the new `oneIdentity` configuration