### PR TITLE
feat: [IEL-726] update FCI API endpoint to use new io-func-sign-user version

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -35,7 +35,7 @@ declare -a noParams=(
 )
 
 declare -a noStrict=(
-  "./generated/definitions/fci https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_io_sign.yaml"
+  "./generated/definitions/fci https://raw.githubusercontent.com/pagopa/io-sign/refs/tags/io-func-sign-user@2.9.2/apps/io-func-sign-user/api/external.yaml"
   "./generated/definitions/idpay https://raw.githubusercontent.com/pagopa/cstar-securehub-infra-api-spec/refs/tags/v3.10.2/src/idpay/apim/api/idpay_appio_full/openapi.appio.full.yml"
   "./generated/definitions/services https://raw.githubusercontent.com/pagopa/io-services-cms/io-services-app-backend@$IO_SERVICES_APP_BACKEND/apps/app-backend/api/external.yaml"
 )


### PR DESCRIPTION
## Short description
Following the separation of FCI from io-backend, the API specs were moved to the FCI monorepo; in this PR, we updated the specs to reflect this change.

## How to test
Test with [this PR](https://github.com/pagopa/io-app/pull/8390) of io-app and try if all work correctly and the client is successfully generated.