### PR TITLE
feat: [EG-3135] [FIMS] Support and validate the FIMS data stream with the Mixpanel ID

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -5,7 +5,7 @@ IO_BACKEND_VERSION=v20.0.0
 # (e.g. api_trial_system.yaml, UserMetadata, ServerInfo from api_backend.yaml)
 IO_BACKEND_LEGACY_VERSION=v17.5.2
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=IEG-3133-FIMS-tracking-Enriched-Urls
+IO_SERVICES_METADATA_VERSION=1.1.3
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # Send Functions

--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -5,7 +5,7 @@ IO_BACKEND_VERSION=v20.0.0
 # (e.g. api_trial_system.yaml, UserMetadata, ServerInfo from api_backend.yaml)
 IO_BACKEND_LEGACY_VERSION=v17.5.2
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.1.2
+IO_SERVICES_METADATA_VERSION=IEG-3133-FIMS-tracking-Enriched-Urls
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # Send Functions

--- a/src/payloads/backend.ts
+++ b/src/payloads/backend.ts
@@ -114,7 +114,8 @@ export const backendStatus: BackendStatus = {
           service_name: "Carta della Cultura - Onboarding"
         }
       ],
-      iOSCookieDisabledServiceIds: ["01JV4M365CHAZN5C0FDR62DCVD"]
+      iOSCookieDisabledServiceIds: ["01JV4M365CHAZN5C0FDR62DCVD"],
+      trackingEnrichedUrls: []
     },
     premiumMessages: {
       opt_in_out_enabled: true


### PR DESCRIPTION
## Short description
This pull request makes a minor update to the backend configuration and the script for generating API models. The main changes are updating the `IO_SERVICES_METADATA_VERSION` to a new branch for enriched URL tracking and adding a new `trackingEnrichedUrls` field to the backend payload.

## List of changes proposed in this pull request
- Updated `IO_SERVICES_METADATA_VERSION` in `scripts/generate-api-models.sh` to use the `IEG-3133-FIMS-tracking-Enriched-Urls` branch, likely to support development related to enriched URL tracking.
- Added a new `trackingEnrichedUrls` field (initialized as an empty array) to the `backendStatus` object in `src/payloads/backend.ts`, preparing for future support of enriched URL tracking.

## How to test
all checks must pass


